### PR TITLE
probe: DCO check must fail on an unsigned commit (close without merging)

### DIFF
--- a/docs/ORCHESTRATION-LOG.md
+++ b/docs/ORCHESTRATION-LOG.md
@@ -61,3 +61,5 @@ hand 2026-08-26); CODEOWNERS names a GitHub user that does not exist.
   are skipped and printed, because `git rebase --signoff` drops them and `main`'s own merges are unsigned. The check
   has never run on GitHub: the throwaway-PR proof (red, not pending) is a supervisor step after the first push.
   T2 dispatched (Docker adapter; must boot the real image on this box). Running: G2, O3, T2.
+
+<!-- DCO probe: this PR is closed without merging; it exists to prove the DCO check goes red on an unsigned commit. -->


### PR DESCRIPTION
Throwaway PR from round wf-os-2026-09-04. Its only commit has no Signed-off-by trailer, so the DCO check must report a failure (not a pending check). It will be amended with -s to prove the check then passes, and closed without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)