### PR TITLE
config: pin the desktop image tag, honest image resolution, local CI pulls the pin, Dependabot bun ecosystems (row I0c)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,36 @@
 # Dependency updates. This repository has five independent JS/TS projects
-# (app, worker, worker/sidecar, sdk, mcp), each with its own lockfile and no
-# root workspace — so each one is listed separately. Grouped and
-# rate-limited on purpose: a small team cannot review a flood of individual
-# bumps, and an unreviewed bump is not an upgrade.
+# (app, worker, worker/sidecar, sdk, mcp) and no root workspace, so each one
+# is listed separately. Grouped and rate-limited on purpose: a small team
+# cannot review a flood of individual bumps, and an unreviewed bump is not an
+# upgrade.
 #
+# ── WHICH ECOSYSTEM, AND WHY IT IS NOT COSMETIC ─────────────────────────────
+# 🔴 FOUR OF THE FIVE ARE `bun`, NOT `npm`. `app/`, `worker/`, `sdk/` and
+# `mcp/` each carry a `bun.lock` and CI installs them with
+# `bun install --frozen-lockfile` (`.github/workflows/ci.yml`). Dependabot's
+# `npm` ecosystem edits `package.json` and updates an npm/yarn/pnpm lockfile
+# — it does not know `bun.lock` exists — so an `npm` entry against a bun
+# project opens a PR whose `package.json` and `bun.lock` disagree, and
+# `--frozen-lockfile` refuses it. That is exactly why PR #5 (the grouped
+# patch-and-minor bump for `/app`) was red on `app` and `shell` and was
+# closed: +7 −7 in one file, no lockfile, unmergeable by construction. Every
+# future `/app` and `/worker` dependency PR would have been the same until
+# this changed. `/sdk` and `/mcp` were already on `bun` (row D1) and their
+# PRs were fine, which is the positive control for this diagnosis.
+#
+# `/worker/sidecar` is the ONE that stays `npm`, and for a measured reason:
+# it has NO lockfile at all (`worker/sidecar/` is `package.json`,
+# `browser.mjs`, `contract.mjs`, `README.md` — nothing else), so there is no
+# bun lockfile for a `bun` entry to maintain. It is also the only entry
+# without a `groups:` block, because a single-package project has nothing to
+# group.
+#
+# 🔴 THE SUPERVISOR ACTION THIS FILE DEPENDS ON: the `dependencies` label
+# every entry below requests must EXIST (`gh label create dependencies`).
+# Dependabot silently skips a label it cannot apply — it does not create one
+# — so until that label exists these `labels:` lines do nothing at all.
+#
+# ── MAJORS ──────────────────────────────────────────────────────────────────
 # Every npm/bun entry below ignores semver-major *version* updates (this
 # does not affect security updates — Dependabot's `ignore` option only
 # applies to routine version updates, so a security advisory whose only fix
@@ -48,7 +75,8 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
-  - package-ecosystem: npm
+  # bun, not npm: app/bun.lock (see the header).
+  - package-ecosystem: bun
     directory: /app
     schedule: { interval: weekly }
     open-pull-requests-limit: 5
@@ -60,7 +88,8 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
-  - package-ecosystem: npm
+  # bun, not npm: worker/bun.lock (see the header).
+  - package-ecosystem: bun
     directory: /worker
     schedule: { interval: weekly }
     open-pull-requests-limit: 5
@@ -75,6 +104,8 @@ updates:
       # ATTRIBUTIONS.md — a bump here is a deliberate, tested change.
       - dependency-name: "@cloudflare/sandbox"
 
+  # 🔴 npm ON PURPOSE, AND THE ONLY ONE. worker/sidecar has no lockfile of any
+  # kind, so there is nothing for a `bun` entry to keep in step.
   - package-ecosystem: npm
     directory: /worker/sidecar
     schedule: { interval: weekly }
@@ -84,8 +115,8 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
-  # sdk/ and mcp/ are managed with Bun (bun.lock), not npm/yarn/pnpm — Bun is
-  # its own Dependabot ecosystem, not a variant of "npm".
+  # sdk/ and mcp/ have been on Bun since row D1 — the working precedent the
+  # /app and /worker entries above were moved to match.
   - package-ecosystem: bun
     directory: /sdk
     schedule: { interval: weekly }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,11 @@
 #   failure: a skip here means the image gate above did not see the pulled
 #   image, which is a finding about this job, never a pass.
 #
-#   `local` — installs and typechecks `local/` for real, ALSO pulls the same
-#   image but tags it under a DIFFERENT local name
-#   (`ezil-os-worker-sandbox:ff199202`, not `ezil-integrated:local` — see the
-#   job's own comment on why: its suites read no env var at all), runs
+#   `local` — installs and typechecks `local/` for real, and pulls the
+#   PINNED reference it reads out of `deploy/images.env`
+#   (`ghcr.io/ezilhq/ezil-os-desktop:$EZIL_DESKTOP_TAG`), not `latest` and not
+#   a re-tag of one — see that job's own comment for why the pin is the only
+#   thing that proves anything here. It runs
 #   `bun run doctor` (`working-directory: local`) as an independent health
 #   check, then
 #   `bun test local/` and inspects the result: `bun test` itself exits 0 when
@@ -64,9 +65,14 @@
 #   FORK PRs CANNOT PULL THE PRIVATE PACKAGE. `pull_request` runs this
 #   workflow with a read-only, fork-scoped `GITHUB_TOKEN` for a fork's PR —
 #   that token cannot pull a private `ezilhq/ezil-os-desktop`, so both
-#   `container` and `local` fail at the "Pull the desktop image" step on
-#   every external contribution, regardless of anything the contributor
-#   wrote. Row G4's required-status list must NOT add "container (real
+#   `container` ("Pull the desktop image") and `local` ("Pull the pinned
+#   desktop image") fail at their pull step on every external contribution,
+#   regardless of anything the contributor wrote. A contributor who wants to
+#   run `local/` on their own machine sets `EZIL_LAUNCHER_IMAGE=<image:tag>`
+#   (`local/src/container/run-spec.ts`'s `DESKTOP_IMAGE_OVERRIDE_ENV`, the
+#   same variable `deploy/launcher/ezil-os.sh` reads) against an image they
+#   built themselves; CI deliberately does not, because this job's job is to
+#   prove the PIN resolves. Row G4's required-status list must NOT add "container (real
 #   image)" or "local (typecheck + unit + smoke)" until the package is made
 #   Public (already tracked as a founder step, docs/ORCHESTRATION-LOG.md
 #   2026-09-04 14:50Z) — otherwise no fork PR could ever merge.
@@ -584,43 +590,74 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # 🔴 SAME PULL AS THE `container` JOB ABOVE, TAGGED UNDER A DIFFERENT
-      # NAME — MEASURED, NOT THE BRIEF'S ORIGINAL ASSUMPTION.
-      # `local/src/host/docker-host.container.test.ts` and
-      # `local/tests/local-smoke.container.test.ts` do NOT read an env var at
-      # all: both call `readAndResolveDesktopImage(deploy/images.env)`
-      # (local/src/container/run-spec.ts:440, calling :415's
-      # `resolveDesktopImage`), which greps `deploy/images.env` for
-      # `EZIL_DESKTOP_IMAGE`/`EZIL_DESKTOP_TAG` and falls back to the literal
-      # `LOCAL_DESKTOP_IMAGE_FALLBACK` constant (run-spec.ts:353) —
-      # `ezil-os-worker-sandbox:ff199202` — whenever the file's tag fails
-      # Docker's tag grammar. `deploy/images.env:90` still ships
-      # `EZIL_DESKTOP_TAG=<to be pinned by CI>` (image.yml's own `desktop`
-      # job runs with `contents: read` and cannot write that pin back — see
-      # that file's own hand-off comment), which does fail the grammar check
-      # (`isDockerTag`, run-spec.ts:389), so on every run today these two
-      # suites resolve to the FALLBACK name, not to any GHCR reference —
-      # tagging the pulled image as `ezil-integrated:local` here (as the
-      # `container` job does) would leave these suites unable to find it. So:
-      # tag the SAME pulled image under the fallback name instead. Once a
-      # human advances `deploy/images.env`'s pin past the placeholder this
-      # step's tag becomes redundant but harmless; nothing here reads the
-      # placeholder itself.
-      - name: Pull the desktop image
+      # 🔴 THIS JOB PULLS THE PIN, NOT `latest` — AND THAT IS THE WHOLE POINT.
+      # `local/src/host/docker-host.container.test.ts`,
+      # `local/tests/local-smoke.container.test.ts` and `bun run doctor` all
+      # resolve their image through `readAndResolveDesktopImage`
+      # (`local/src/container/run-spec.ts`), which reads
+      # `EZIL_DESKTOP_IMAGE`/`EZIL_DESKTOP_TAG` out of `deploy/images.env`.
+      #
+      # Until row I0c that file carried `EZIL_DESKTOP_TAG=<to be pinned by CI>`
+      # and the resolver quietly substituted the literal
+      # `ezil-os-worker-sandbox:ff199202`, so this step pulled `latest` and
+      # re-tagged it under that literal to make the suites find something. The
+      # comment that stood here claimed the re-tag would become "redundant but
+      # harmless" once a human advanced the pin. That was WRONG, and it is the
+      # reason this step is rewritten in the same commit as the pin: with a
+      # real pin the resolver composes `ghcr.io/ezilhq/ezil-os-desktop:<sha8>`,
+      # the doctor inspects THAT reference, and a locally-tagged
+      # `ezil-os-worker-sandbox:ff199202` is not it — the doctor would have
+      # failed and the container suites would have skipped, on a green pull.
+      #
+      # So: read the pin the same way `image.yml`'s "Load image pins" step
+      # does (grep, never `source` — this file is deliberately not
+      # shell-sourceable), check it against Docker's tag grammar before using
+      # it, and pull exactly the reference `local/` will resolve. No re-tag.
+      # Nothing here sets `EZIL_LAUNCHER_IMAGE`: this job exists to prove the
+      # PIN resolves, and an override would prove something else.
+      #
+      # 🔴 THE PIN, NOT THIS COMMIT'S OWN sha8 — the distinction the file
+      # header's "WHICH TAG, AND WHY" is about. `image.yml` runs concurrently
+      # with this workflow and never on a `pull_request`, so this commit's own
+      # sha8 may not exist in GHCR yet; the pinned sha8 is a tag a PREVIOUS
+      # successful `image.yml` run already pushed, is immutable, and is
+      # therefore always resolvable. A pin advanced to a tag that was never
+      # published makes this step fail loudly — the honest failure, and the
+      # reason `deploy/images.env`'s write-back rule says to advance the pin
+      # only from a published run's `published-images.env` artifact.
+      - name: Pull the pinned desktop image
         shell: bash
         run: |
           set -e
-          image="ghcr.io/ezilhq/ezil-os-desktop:latest"
-          echo "[image] pulling ${image} ..."
+          # Same helper as .github/workflows/image.yml's "Load image pins".
+          read_env_key() { grep -E "^[[:space:]]*${1}[[:space:]]*=" "$2" | head -1 | cut -d= -f2- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'; }
+          desktop_image="$(read_env_key EZIL_DESKTOP_IMAGE deploy/images.env)"
+          desktop_tag="$(read_env_key EZIL_DESKTOP_TAG deploy/images.env)"
+          if [ -z "${desktop_image}" ] || [ -z "${desktop_tag}" ]; then
+            echo "::error::deploy/images.env is missing EZIL_DESKTOP_IMAGE or EZIL_DESKTOP_TAG - local/ resolves its image from those two keys and cannot run without them."
+            exit 1
+          fi
+          # The SAME grammar as run-spec.ts's isDockerTag. Without this a
+          # re-introduced placeholder would reach `docker pull` and fail with
+          # an error about a reference format, not about the pin.
+          if ! printf '%s' "${desktop_tag}" | grep -qE '^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$'; then
+            echo "::error::deploy/images.env's EZIL_DESKTOP_TAG ('${desktop_tag}') is not a valid Docker tag, so local/ resolves no image at all. Advance the pin from a successful image.yml run's published-images.env artifact (gh run download <run-id> -n published-images.env) - see deploy/images.env's own write-back rule."
+            exit 1
+          fi
+          if [ "${desktop_tag}" = "latest" ]; then
+            echo "::error::deploy/images.env pins EZIL_DESKTOP_TAG=latest. A floating tag means two users on 'the same version' run different bytes - see that file's tag-scheme comment. Pin a sha8 or a semver."
+            exit 1
+          fi
+          image="${desktop_image}:${desktop_tag}"
+          echo "[image] pulling the PINNED reference ${image} (from deploy/images.env) ..."
           if ! pull_out="$(docker pull "${image}" 2>&1)"; then
             printf '%s\n' "${pull_out}"
-            echo "::error::docker pull ${image} was refused. The ezilhq/ezil-os-desktop package publishes PRIVATE by default and this job already has packages: read (see this job's permissions: block), but that alone is not always enough - check the package's own Actions-access setting at https://github.com/orgs/EZiLHQ/packages/container/ezil-os-desktop/settings (Manage Actions access -> this repository at Read), or make the package Public."
+            echo "::error::docker pull ${image} was refused. Two causes, in order of likelihood: (1) the ezilhq/ezil-os-desktop package publishes PRIVATE by default and this job already has packages: read (see this job's permissions: block), but that alone is not always enough - check the package's own Actions-access setting at https://github.com/orgs/EZiLHQ/packages/container/ezil-os-desktop/settings (Manage Actions access -> this repository at Read), or make the package Public; (2) the pin in deploy/images.env names a tag image.yml never published - advance it from a successful run's published-images.env artifact."
             exit 1
           fi
           printf '%s\n' "${pull_out}"
           digest="$(printf '%s\n' "${pull_out}" | grep -oE 'Digest: sha256:[0-9a-f]+' | head -1)"
           echo "[image] tested build: ${image}  ${digest:-<no Digest line printed by docker pull>}"
-          docker tag "${image}" ezil-os-worker-sandbox:ff199202
       # `local/tsconfig.json`'s own header comment: its typecheck reaches
       # `app/src/server/shell/boot-payload.ts`, which imports `drizzle-orm`
       # through `app/node_modules` — so `bun run --cwd local typecheck` needs
@@ -669,10 +706,10 @@ jobs:
       # 🔴 HARD-FAIL ON A SKIP, NOT JUST ON A FAILURE.
       # `local/src/host/docker-host.container.test.ts` and
       # `local/tests/local-smoke.container.test.ts` gate on `docker image
-      # inspect` for the image `readAndResolveDesktopImage` resolves (see the
-      # "Pull the desktop image" step above for why that is the FALLBACK
-      # name, not a GHCR reference) and SKIP — do not fail — when it is
-      # absent. `bun test`'s OWN exit code is 0 on a run with skips and zero
+      # inspect` for the image `readAndResolveDesktopImage` resolves — since
+      # row I0c that is `deploy/images.env`'s PINNED GHCR reference, exactly
+      # what the "Pull the pinned desktop image" step above pulled — and SKIP
+      # — do not fail — when it is absent. `bun test`'s OWN exit code is 0 on a run with skips and zero
       # failures (measured: a `describe.skipIf(true)` suite exits 0), so
       # without the check below this job would read as fully green while the
       # suites that boot a real desktop in a real browser never ran once. So:

--- a/artifacts/runs/wf-os-2026-09-04/I0c.json
+++ b/artifacts/runs/wf-os-2026-09-04/I0c.json
@@ -1,0 +1,9 @@
+{
+  "taskId": "I0c",
+  "runId": "wf-os-2026-09-04",
+  "status": "running",
+  "doneRung": "STARTED",
+  "evidence": "worktree created at base 3c76d43; newest successful image.yml run on main = 33876458193 (headSha 3c76d43bf..., conclusion success); its published-images.env artifact downloaded (458 B) and reads EZIL_DESKTOP_TAG=3c76d43b, digest sha256:0b90b66d13bb2f1e84a7d254878bd390e1e45f181bb19000a4451f06692e683f; the run log confirms `pushing manifest for ghcr.io/ezilhq/ezil-os-desktop:3c76d43b@sha256:0b90b66d...` so the tag really exists in GHCR. Override image ezil-os-worker-sandbox:ff199202 confirmed present locally (sha256:14ae1a93998f...). No edits yet.",
+  "startedAt": "2026-09-04T00:00:00Z",
+  "updatedAt": "2026-09-04T00:00:00Z"
+}

--- a/deploy/images.env
+++ b/deploy/images.env
@@ -63,31 +63,47 @@
 #   bump, or vice versa, fails the build rather than silently drifting.
 
 EZIL_DESKTOP_IMAGE=ghcr.io/ezilhq/ezil-os-desktop
-# 🔴 PLACEHOLDER, ON PURPOSE, AND IT IS NOT A VALID DOCKER TAG.
-# Nothing has been pushed to GHCR yet (no tags exist in this repository, so
-# `deploy.yml` has never run). `run-spec.ts` validates every tag it reads
-# against Docker's tag grammar and REFUSES to compose a reference from one
-# that fails, falling back to `LOCAL_DESKTOP_IMAGE_FALLBACK` — the image the
-# `worker/Dockerfile` build actually produces on this machine — and saying so.
-# A placeholder that looks like configuration must fail at read time, not at
-# `docker run` time. CI replaces this with the build's short SHA.
+# 🔴 A REAL PIN, ADVANCED BY HAND FROM A PUBLISHED BUILD — NEVER BY A ROBOT.
+# Pinned 2026-09-04 from `.github/workflows/image.yml` run 33876458193
+# (commit 3c76d43bf1a7602fa48c33f43a90f900229b43f8, its `published-images.env`
+# artifact), whose log shows the push:
+#   pushing manifest for ghcr.io/ezilhq/ezil-os-desktop:3c76d43b
+#     @sha256:0b90b66d13bb2f1e84a7d254878bd390e1e45f181bb19000a4451f06692e683f
+# The digest is recorded here as a COMMENT and not as an `EZIL_DESKTOP_DIGEST`
+# key on purpose: `deploy/launcher/ezil-os.sh` reads that key and EXITS 2 when
+# it does not appear in `docker image inspect --format '{{join .RepoDigests}}'`,
+# and whether `docker push`'s printed manifest digest is the same digest that
+# command reports (index vs platform manifest) is an untested hypothesis on
+# this repository. Setting the key would ship that hypothesis to every user.
 #
-# 🔴 HAND-OFF: `.github/workflows/image.yml`'s `desktop` job runs with
-# `permissions: contents: read` on purpose (a workflow committing to `main`
-# needs `contents: write` and races the branch ruleset), so it CANNOT write
-# the tag it just published back into this file. Instead it publishes the
-# published tag + digest two ways: the run's job summary (human-readable),
-# and an uploaded `actions/upload-artifact@v4` artifact named
-# `published-images.env` containing a ready-to-paste `EZIL_DESKTOP_TAG=<sha8>`
-# line. A human (or row R2's release step) advances this pin from that
-# artifact:
+# ── HOW THIS VALUE ADVANCES (the write-back rule) ───────────────────────────
+# `image.yml`'s `desktop` job runs with `permissions: contents: read` on
+# purpose (a workflow committing to `main` needs `contents: write` and races
+# the branch ruleset), so it CANNOT write back the tag it just published. It
+# publishes it two ways instead — the run's job summary, and an uploaded
+# `published-images.env` artifact — and a human advances the pin from that
+# artifact, in its own commit, AFTER the build succeeded:
+#   gh run list -R EZiLHQ/ezil-os --workflow image.yml --branch main -L 3 \
+#       --json databaseId,conclusion,headSha
 #   gh run download <run-id> -R EZiLHQ/ezil-os -n published-images.env
-#   # then paste its EZIL_DESKTOP_TAG=<sha8> line over the one below, commit.
-# Until that happens this placeholder stays exactly as shipped — it already
-# fails `isDockerTag`'s grammar check (`run-spec.ts`), so `resolveDesktopImage`
-# already falls back to `LOCAL_DESKTOP_IMAGE_FALLBACK` with a named reason
-# instead of composing a broken reference. No value change was needed here.
-EZIL_DESKTOP_TAG=<to be pinned by CI>
+#   # paste its EZIL_DESKTOP_TAG=<sha8> line over the one below; copy the
+#   # `# digest:` line into the comment above it; commit.
+# The producing half of this rule is `.github/workflows/image.yml`'s "Write
+# published-images.env" step, whose own comment carries the same two commands;
+# `docs/RELEASE.md` § "Order of events on a tag" shows where in a release the
+# sha8 this rule advances is published. (`docs/RELEASE.md` has no step of its
+# own for the write-back yet — adding one is a hand-off; row I0c did not own
+# that file.)
+# NEVER pin a sha8 whose build has not been published: `.github/workflows/
+# ci.yml`'s `local` job pulls exactly this reference, so an unpublished pin is
+# a red CI run — the honest failure, and the point.
+#
+# 🔴 NEVER `latest` HERE (see the tag scheme above), and never a value that is
+# not a Docker tag: `run-spec.ts`'s `isDockerTag` refuses to compose a
+# reference from one, and since row I0c that refusal is FATAL — local mode
+# reports `images_env_bad_tag` and stops, rather than quietly running some
+# other image that happens to exist on the machine.
+EZIL_DESKTOP_TAG=3c76d43b
 
 EZIL_NEKO_IMAGE=ghcr.io/ezilhq/ezil-neko-vscode
 EZIL_NEKO_TAG=d74052bb-049931d7

--- a/local/src/container/run-spec.test.ts
+++ b/local/src/container/run-spec.test.ts
@@ -23,6 +23,7 @@ import {
     CONTAINER_WORKSPACE_PATH,
     FOCUS_APPS,
     GUACAMOLE_HTTP_PORT,
+    DESKTOP_IMAGE_OVERRIDE_ENV,
     IMAGES_ENV_RELATIVE_PATH,
     LOCAL_BIND_ADDRESS,
     LOCAL_DESKTOP_IMAGE_FALLBACK,
@@ -44,9 +45,11 @@ import {
     formatLocalNekoScreen,
     isDockerTag,
     isEnvName,
+    isResolved,
     localUrlFor,
     parseImagesEnv,
     publishedPort,
+    readAndResolveDesktopImage,
     resolveDesktopImage,
     type DockerRunSpec,
     NEKO_IMPLICIT_HOSTING_ENV,
@@ -359,26 +362,38 @@ describe('deploy/images.env', () => {
         expect(ENTRIES['EZIL_NEKO_TAG']).not.toBe('latest');
     });
 
-    // Stated as an INVARIANT, so it stays true after row T3 pins a real tag:
-    // a usable tag resolves from the file, an unusable one resolves to the
-    // fallback and says why. Today the file carries the placeholder, so this
-    // exercises the fallback branch against real shipped content.
-    it('resolves to a runnable reference either way, and never composes a placeholder', () => {
-        const resolved = resolveDesktopImage(ENTRIES);
+    // 🔴 EVERY CALL BELOW PASSES AN EXPLICIT `env`, NEVER THE DEFAULT.
+    // `resolveDesktopImage(entries, env = process.env)` honours
+    // `EZIL_LAUNCHER_IMAGE` FIRST, and this suite is routinely run on a box
+    // where that variable is exported (it is how a developer who cannot pull
+    // the private GHCR package runs the container suites at all). A test that
+    // let the default through would assert about the developer's shell instead
+    // of about the shipped file, and would flip colour with no code change.
+    const NO_ENV: Record<string, string | undefined> = {};
+
+    // 🔴 THE ASSERTION THE PLACEHOLDER ERA COULD NOT MAKE. Until row I0c this
+    // file shipped `EZIL_DESKTOP_TAG=<to be pinned by CI>` and the resolver
+    // quietly substituted `LOCAL_DESKTOP_IMAGE_FALLBACK`, so "local mode
+    // starts" proved nothing about the pin. The pin is now real and this is
+    // unconditional: the shipped file resolves, from the file, to the pinned
+    // reference — no fallback branch exists to hide behind.
+    it('the shipped pin resolves to the pinned reference, from the file, with no reason', () => {
         const tag = ENTRIES['EZIL_DESKTOP_TAG'] ?? '';
-        if (isDockerTag(tag)) {
-            expect(resolved.source).toBe('images.env');
-            expect(resolved.ref).toBe(`${ENTRIES['EZIL_DESKTOP_IMAGE']}:${tag}`);
-        } else {
-            expect(resolved.source).toBe('fallback');
-            expect(resolved.reason).toMatch(/images_env_bad_tag/);
-            expect(resolved.ref).toBe(LOCAL_DESKTOP_IMAGE_FALLBACK);
-        }
-        // Whichever branch ran, the result is a syntactically valid reference —
-        // this is the assertion that would have caught `<to be pinned by CI>`.
+        expect(isDockerTag(tag)).toBe(true);
+        const resolved = resolveDesktopImage(ENTRIES, NO_ENV);
+        expect(resolved.source).toBe('images.env');
+        expect(resolved.reason).toBeUndefined();
+        expect(resolved.ref).toBe(`${ENTRIES['EZIL_DESKTOP_IMAGE']}:${tag}`);
+        expect(isResolved(resolved)).toBe(true);
+        // A syntactically valid reference, whatever the values are — this is
+        // the assertion that would have caught `<to be pinned by CI>`.
         expect(resolved.ref).toMatch(/^[a-z0-9][a-z0-9._/-]*:[A-Za-z0-9_][A-Za-z0-9._-]*$/);
         expect(resolved.ref).not.toContain(' ');
         expect(resolved.ref).not.toContain('<');
+    });
+
+    it('the tag is a git sha8 or a semver, never a floating name', () => {
+        expect(ENTRIES['EZIL_DESKTOP_TAG']).toMatch(/^([0-9a-f]{8}|\d+\.\d+\.\d+(-[A-Za-z0-9.]+)?)$/);
     });
 
     it('the shipped placeholder is rejected by the tag grammar (positive control: a real tag is not)', () => {
@@ -390,14 +405,111 @@ describe('deploy/images.env', () => {
         expect(isDockerTag('0.3.1')).toBe(true);
     });
 
-    it('falls back with a named reason for every unusable shape', () => {
-        expect(resolveDesktopImage({}).reason).toMatch(/images_env_incomplete/);
-        expect(resolveDesktopImage({ EZIL_DESKTOP_IMAGE: 'ghcr.io/x/y' }).reason).toMatch(/images_env_incomplete/);
-        expect(resolveDesktopImage({ EZIL_DESKTOP_IMAGE: 'BAD NAME', EZIL_DESKTOP_TAG: 'v1' }).reason)
+    // 🔴 THE MUTATION THIS SUITE EXISTS FOR. Restore the placeholder into the
+    // real file and `the shipped pin resolves…` above goes red; this case is
+    // the same fact stated on synthetic entries, so the reason is checkable
+    // without editing anything.
+    it('an unusable pin is UNRESOLVED with a named reason — it never becomes a literal', () => {
+        const placeholder = resolveDesktopImage(
+            { EZIL_DESKTOP_IMAGE: 'ghcr.io/ezilhq/ezil-os-desktop', EZIL_DESKTOP_TAG: '<to be pinned by CI>' },
+            NO_ENV,
+        );
+        expect(placeholder.source).toBe('unresolved');
+        expect(placeholder.reason).toMatch(/images_env_bad_tag/);
+        expect(placeholder.ref).toBe('');
+        expect(isResolved(placeholder)).toBe(false);
+        // The literal is NOT what an unusable pin resolves to any more. This is
+        // the regression guard for the defect row I0c removed.
+        expect(placeholder.ref).not.toBe(LOCAL_DESKTOP_IMAGE_FALLBACK);
+        // And the reason names the way out, or a user reading it is stuck.
+        expect(placeholder.reason).toContain(DESKTOP_IMAGE_OVERRIDE_ENV);
+    });
+
+    it('every unusable shape is unresolved, with its own named reason', () => {
+        expect(resolveDesktopImage({}, NO_ENV).reason).toMatch(/images_env_incomplete/);
+        expect(resolveDesktopImage({ EZIL_DESKTOP_IMAGE: 'ghcr.io/x/y' }, NO_ENV).reason).toMatch(/images_env_incomplete/);
+        expect(resolveDesktopImage({ EZIL_DESKTOP_IMAGE: 'BAD NAME', EZIL_DESKTOP_TAG: 'v1' }, NO_ENV).reason)
             .toMatch(/images_env_bad_image_name/);
+        const unusable: Record<string, string>[] = [
+            {},
+            { EZIL_DESKTOP_IMAGE: 'ghcr.io/x/y' },
+            { EZIL_DESKTOP_IMAGE: 'BAD NAME', EZIL_DESKTOP_TAG: 'v1' },
+        ];
+        for (const entries of unusable) {
+            expect(resolveDesktopImage(entries, NO_ENV).source).toBe('unresolved');
+            expect(resolveDesktopImage(entries, NO_ENV).ref).toBe('');
+        }
         // Positive control: a good pair resolves from the file with no reason.
-        const ok = resolveDesktopImage({ EZIL_DESKTOP_IMAGE: 'ghcr.io/ezilhq/ezil-os-desktop', EZIL_DESKTOP_TAG: 'abc12345' });
+        const ok = resolveDesktopImage(
+            { EZIL_DESKTOP_IMAGE: 'ghcr.io/ezilhq/ezil-os-desktop', EZIL_DESKTOP_TAG: 'abc12345' },
+            NO_ENV,
+        );
         expect(ok).toEqual({ ref: 'ghcr.io/ezilhq/ezil-os-desktop:abc12345', source: 'images.env' });
+    });
+
+    // ── The override ─────────────────────────────────────────────────────────
+    //
+    // 🔴 ONE VARIABLE, ONE MEANING. `DESKTOP_IMAGE_OVERRIDE_ENV` is
+    // `EZIL_LAUNCHER_IMAGE` — the name `deploy/launcher/ezil-os.sh:85` already
+    // reads to choose which image it PULLS. Before row I0c the launcher pulled
+    // the override and then started a host that resolved `deploy/images.env`
+    // instead, so the two halves ran different images. Pinning the NAME here is
+    // what keeps that true; a rename in run-spec.ts alone turns this red.
+    it('the override variable is the launcher\'s own, spelled exactly once', () => {
+        expect(DESKTOP_IMAGE_OVERRIDE_ENV).toBe('EZIL_LAUNCHER_IMAGE');
+        const launcher = readFileSync(join(REPO_ROOT, 'deploy', 'launcher', 'ezil-os.sh'), 'utf8');
+        expect(launcher).toContain(DESKTOP_IMAGE_OVERRIDE_ENV);
+        // Negative control on the name that would have collided:
+        // `EZIL_DESKTOP_IMAGE` is a KEY in deploy/images.env meaning a BARE
+        // registry path. Using it as the override too would mean one name with
+        // two shapes — exactly the EZIL_NEKO_IMAGE collision row M1 logged.
+        expect(DESKTOP_IMAGE_OVERRIDE_ENV).not.toBe('EZIL_DESKTOP_IMAGE');
+    });
+
+    it('the override WINS over a perfectly good pin', () => {
+        const resolved = resolveDesktopImage(ENTRIES, { [DESKTOP_IMAGE_OVERRIDE_ENV]: 'ezil-os-worker-sandbox:ff199202' });
+        expect(resolved.source).toBe('override');
+        expect(resolved.ref).toBe('ezil-os-worker-sandbox:ff199202');
+        expect(resolved.reason).toBeUndefined();
+        // Positive control: the SAME entries with no override resolve from the
+        // file — so this test is about the override, not about the entries.
+        expect(resolveDesktopImage(ENTRIES, NO_ENV).source).toBe('images.env');
+    });
+
+    it('the override rescues an unusable pin, and an empty override does not fire', () => {
+        const broken = { EZIL_DESKTOP_IMAGE: 'ghcr.io/ezilhq/ezil-os-desktop', EZIL_DESKTOP_TAG: '<to be pinned by CI>' };
+        expect(resolveDesktopImage(broken, { [DESKTOP_IMAGE_OVERRIDE_ENV]: 'my-desktop:local' }))
+            .toEqual({ ref: 'my-desktop:local', source: 'override' });
+        // Unset, empty and whitespace-only are all "no override" — an exported
+        // but empty variable must not resolve to `''` and then be run.
+        for (const value of [undefined, '', '   ']) {
+            expect(resolveDesktopImage(broken, { [DESKTOP_IMAGE_OVERRIDE_ENV]: value }).source).toBe('unresolved');
+        }
+    });
+
+    it('an override that is not <name>:<tag> is refused by name, not waved through', () => {
+        for (const bad of ['ghcr.io/ezilhq/ezil-os-desktop', 'no-tag', 'name:<to be pinned by CI>', 'BAD NAME:v1', 'name:']) {
+            const resolved = resolveDesktopImage(ENTRIES, { [DESKTOP_IMAGE_OVERRIDE_ENV]: bad });
+            expect(resolved.source).toBe('unresolved');
+            expect(resolved.reason).toMatch(/override_invalid/);
+            expect(resolved.ref).toBe('');
+        }
+        // Positive controls: the shapes a developer actually types.
+        for (const good of ['ezil-os-worker-sandbox:ff199202', 'ghcr.io/ezilhq/ezil-os-desktop:3c76d43b', 'localhost:5000/x:v1.2.3']) {
+            expect(resolveDesktopImage(ENTRIES, { [DESKTOP_IMAGE_OVERRIDE_ENV]: good }).source).toBe('override');
+        }
+    });
+
+    it('an unreadable images.env is unresolved, unless the override supplies one', async () => {
+        const missing = join(REPO_ROOT, 'deploy', 'no-such-images.env');
+        const without = await readAndResolveDesktopImage(missing, NO_ENV);
+        expect(without.source).toBe('unresolved');
+        expect(without.reason).toMatch(/images_env_unreadable/);
+        expect(without.reason).toContain(DESKTOP_IMAGE_OVERRIDE_ENV);
+        const withOverride = await readAndResolveDesktopImage(missing, { [DESKTOP_IMAGE_OVERRIDE_ENV]: 'my-desktop:local' });
+        expect(withOverride).toEqual({ ref: 'my-desktop:local', source: 'override' });
+        // Positive control: the REAL file at the same path prefix does resolve.
+        expect((await readAndResolveDesktopImage(IMAGES_ENV_PATH, NO_ENV)).source).toBe('images.env');
     });
 
     it('the parser drops comments and blanks and keeps values containing "="', () => {

--- a/local/src/container/run-spec.ts
+++ b/local/src/container/run-spec.ts
@@ -340,17 +340,53 @@ export function assertUsableScreen(screen: ScreenMode): void {
 // ── The image reference ──────────────────────────────────────────────────────
 
 /**
- * The image local mode falls back to when `deploy/images.env` carries no
- * usable pin.
+ * The image `DockerHost` runs when its constructor is handed no `image` at
+ * all — its own default, and NOT a fallback for an unusable pin.
  *
- * This is what `docker build -t … worker/` produces on a developer machine
- * today, and it is a REAL, RUNNABLE reference — unlike
- * `ghcr.io/ezilhq/ezil-os-desktop:<to be pinned by CI>`, which is what
- * `deploy/images.env` currently holds because nothing has been pushed to GHCR
- * yet. Row T3 pins the published tag; until then a fallback that exists beats
- * a reference that composes cleanly and then 404s at `docker run`.
+ * 🔴 IT USED TO BE BOTH, AND THAT WAS THE DEFECT ROW I0c REMOVED.
+ * `resolveDesktopImage` used to substitute this literal whenever
+ * `deploy/images.env` carried a tag it could not use — which it did, because
+ * the file shipped `EZIL_DESKTOP_TAG=<to be pinned by CI>`. Local mode
+ * therefore started, every doctor line was green, and nothing anyone ran had
+ * any relationship to the pinned configuration: "a value that looks like
+ * configuration and is not one" (docs/CONFIDENCE-MAP.md §0.4). A resolver
+ * that cannot honour the pin now says so and stops; the only way to run some
+ * OTHER image is to ask for it BY NAME through `DESKTOP_IMAGE_OVERRIDE_ENV`.
+ *
+ * The value is what `docker build -t … worker/` produces on a developer
+ * machine, so `new DockerHost()` with no options is still runnable in a test.
+ *
+ * 🔴 HAND-OFF (not this row's file): `local/src/host/docker-host.ts:234` does
+ * `options.image ?? LOCAL_DESKTOP_IMAGE_FALLBACK` — the same silent-fallback
+ * shape one layer down. `DockerHostOptions.image` should become required so
+ * the production wiring cannot construct a host against a literal nobody
+ * configured.
  */
 export const LOCAL_DESKTOP_IMAGE_FALLBACK = 'ezil-os-worker-sandbox:ff199202';
+
+/**
+ * The ONE environment variable that overrides the pinned desktop image.
+ *
+ * 🔴 IT IS THE LAUNCHER'S OWN VARIABLE, ON PURPOSE — ONE NAME, ONE MEANING.
+ * `deploy/launcher/ezil-os.sh:85` already reads `EZIL_LAUNCHER_IMAGE` to pick
+ * which image it pulls, and then runs `bun run --cwd local doctor` and
+ * `start` as child processes that inherit it. Before this row those two
+ * halves disagreed: the launcher pulled the override and the host it started
+ * resolved `deploy/images.env` instead, so `EZIL_LAUNCHER_IMAGE=x` pulled `x`
+ * and ran something else. Honouring the same name here is what makes the
+ * launcher's own documented override true end to end.
+ *
+ * Deliberately NOT `EZIL_DESKTOP_IMAGE`: that name is already a KEY in
+ * `deploy/images.env` meaning a bare registry path with no tag. One name
+ * meaning "bare path" in a file and "full name:tag" in the environment is
+ * exactly the `EZIL_NEKO_IMAGE` collision row M1 logged
+ * (docs/ORCHESTRATION-LOG.md, 2026-09-05 01:30Z).
+ *
+ * Who needs it: anyone who cannot pull `ghcr.io/ezilhq/ezil-os-desktop` —
+ * the package is PRIVATE until the founder flips its visibility — and anyone
+ * running an image they built themselves from `worker/Dockerfile`.
+ */
+export const DESKTOP_IMAGE_OVERRIDE_ENV = 'EZIL_LAUNCHER_IMAGE';
 
 /** Path of the pinned-image file, relative to the repository root. */
 export const IMAGES_ENV_RELATIVE_PATH = 'deploy/images.env';
@@ -380,11 +416,12 @@ export function parseImagesEnv(text: string): Record<string, string> {
  * Docker's own tag grammar: `[A-Za-z0-9_][A-Za-z0-9._-]{0,127}`.
  *
  * 🔴 THIS IS THE GUARD THAT KEEPS A PLACEHOLDER OUT OF AN ARGV.
- * `deploy/images.env` ships `EZIL_DESKTOP_TAG=<to be pinned by CI>` on purpose.
- * Without this check that string composes into
+ * `deploy/images.env` shipped `EZIL_DESKTOP_TAG=<to be pinned by CI>` for the
+ * whole of round ANYWHERE. Without this check that string composes into
  * `ghcr.io/ezilhq/ezil-os-desktop:<to be pinned by CI>` — a value that looks
  * exactly like configuration, passes every "is it set?" test, and fails only at
- * the moment a user tries to start their computer.
+ * the moment a user tries to start their computer. The file now carries a real
+ * pin, and this guard is what keeps the next one honest.
  */
 export function isDockerTag(tag: string): boolean {
     return /^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$/.test(tag);
@@ -396,55 +433,141 @@ export function isDockerImageName(name: string): boolean {
 }
 
 export interface ResolvedImage {
-    /** The reference to hand `docker run`. Always a syntactically valid `name:tag`. */
+    /**
+     * The reference to hand `docker run` — a syntactically valid `name:tag`
+     * when `source` is `'images.env'` or `'override'`, and the EMPTY STRING
+     * when `source` is `'unresolved'`.
+     *
+     * 🔴 CHECK `source`, NOT TRUTHINESS OF `ref` ALONE — or use `isResolved`.
+     * `ref` is typed `string` rather than `string | null` only because two
+     * call sites this row does not own (`local/src/config.ts:298`,
+     * `local/src/server/main.ts:61`) would not compile against a nullable
+     * one; the empty string is a value no `docker` subcommand accepts, so a
+     * caller that ignores `source` fails loudly at the daemon instead of
+     * running the wrong image quietly.
+     */
     readonly ref: string;
-    /** Where it came from. `'fallback'` always carries a `reason`. */
-    readonly source: 'images.env' | 'fallback';
-    /** Why the file's value was not usable. Present iff `source === 'fallback'`. */
+    /**
+     * Where it came from:
+     *   `'override'`    — `DESKTOP_IMAGE_OVERRIDE_ENV` was set and usable; it
+     *                     wins over the file, always, and the file is not even
+     *                     read for the name/tag.
+     *   `'images.env'`  — the pinned `EZIL_DESKTOP_IMAGE`/`_TAG` pair.
+     *   `'unresolved'`  — neither produced a usable reference. Always carries
+     *                     a `reason`, and local mode must refuse to start.
+     */
+    readonly source: 'images.env' | 'override' | 'unresolved';
+    /** Why nothing usable was produced. Present iff `source === 'unresolved'`. */
     readonly reason?: string;
 }
 
+/** `true` when this resolution names an image something can actually be asked to run. */
+export function isResolved(image: ResolvedImage): boolean {
+    return image.source !== 'unresolved' && image.ref !== '';
+}
+
 /**
- * Resolve the desktop image from parsed `deploy/images.env` entries, or say why
- * it could not and fall back to something that actually exists.
- *
- * Never throws and never returns a malformed reference: a caller that ignores
- * `source`/`reason` still gets a runnable image, and a caller that reads them
- * can tell the user their pin was not usable.
+ * The one sentence every "unresolved" reason ends with. Naming the override is
+ * the difference between a user who is stuck and a user who is running.
  */
-export function resolveDesktopImage(entries: Record<string, string>): ResolvedImage {
+function overrideHint(): string {
+    return `set ${DESKTOP_IMAGE_OVERRIDE_ENV}=<image:tag> to run an image you already have`
+        + ' (the same variable `deploy/launcher/ezil-os.sh` reads), or advance the pin in'
+        + ' `deploy/images.env` per that file\'s write-back rule';
+}
+
+/**
+ * Resolve the desktop image from the environment override first, then from
+ * parsed `deploy/images.env` entries — or say, in a named reason, why neither
+ * produced a reference and refuse to name one.
+ *
+ * 🔴 NEVER FALLS BACK TO A LITERAL. Until row I0c it did, and a placeholder pin
+ * therefore started local mode against `LOCAL_DESKTOP_IMAGE_FALLBACK` while
+ * every check reported green. Configuration that cannot be honoured is a
+ * failure, not a default.
+ *
+ * Still never throws: every caller gets a value it can report on, and the
+ * `'unresolved'` branch is a decision the caller makes loudly (see
+ * `local/src/doctor.ts`'s `desktop image` check), not an exception it may drop.
+ *
+ * `env` is a PARAMETER, not a `process.env` read inside the function, so this
+ * stays pure and testable: `bun test` runs a file's cases in one process, and a
+ * suite that mutated `process.env` to test the override would be order-
+ * dependent.
+ */
+export function resolveDesktopImage(
+    entries: Record<string, string>,
+    env: Record<string, string | undefined> = process.env,
+): ResolvedImage {
+    // ── 1. The override, which wins over the file. ───────────────────────────
+    // Validated with the SAME grammar as the file's pin, not waved through: an
+    // override is configuration too, and `EZIL_LAUNCHER_IMAGE=ghcr.io/x/y`
+    // (no tag) would silently mean `:latest` — the one tag `deploy/images.env`
+    // calls a bug.
+    const raw = (env[DESKTOP_IMAGE_OVERRIDE_ENV] ?? '').trim();
+    if (raw !== '') {
+        const cut = raw.lastIndexOf(':');
+        const name = cut === -1 ? raw : raw.slice(0, cut);
+        const tag = cut === -1 ? '' : raw.slice(cut + 1);
+        if (cut === -1 || !isDockerImageName(name) || !isDockerTag(tag)) {
+            return {
+                ref: '',
+                source: 'unresolved',
+                reason: `override_invalid: ${DESKTOP_IMAGE_OVERRIDE_ENV}='${raw}' is not <name>:<tag>`
+                    + ' (an untagged reference would mean `:latest`, which this product never pins)',
+            };
+        }
+        return { ref: `${name}:${tag}`, source: 'override' };
+    }
+
+    // ── 2. The pin. ──────────────────────────────────────────────────────────
     const name = entries['EZIL_DESKTOP_IMAGE'] ?? '';
     const tag = entries['EZIL_DESKTOP_TAG'] ?? '';
     if (name === '' || tag === '') {
         return {
-            ref: LOCAL_DESKTOP_IMAGE_FALLBACK,
-            source: 'fallback',
-            reason: `images_env_incomplete: EZIL_DESKTOP_IMAGE=${name === '' ? '(unset)' : name}, EZIL_DESKTOP_TAG=${tag === '' ? '(unset)' : tag}`,
+            ref: '',
+            source: 'unresolved',
+            reason: `images_env_incomplete: EZIL_DESKTOP_IMAGE=${name === '' ? '(unset)' : name},`
+                + ` EZIL_DESKTOP_TAG=${tag === '' ? '(unset)' : tag} — ${overrideHint()}`,
         };
     }
     if (!isDockerImageName(name)) {
-        return { ref: LOCAL_DESKTOP_IMAGE_FALLBACK, source: 'fallback', reason: `images_env_bad_image_name: '${name}'` };
+        return { ref: '', source: 'unresolved', reason: `images_env_bad_image_name: '${name}' — ${overrideHint()}` };
     }
     if (!isDockerTag(tag)) {
-        return { ref: LOCAL_DESKTOP_IMAGE_FALLBACK, source: 'fallback', reason: `images_env_bad_tag: '${tag}' is not [A-Za-z0-9_][A-Za-z0-9._-]{0,127}` };
+        return {
+            ref: '',
+            source: 'unresolved',
+            reason: `images_env_bad_tag: '${tag}' is not [A-Za-z0-9_][A-Za-z0-9._-]{0,127} — ${overrideHint()}`,
+        };
     }
     return { ref: `${name}:${tag}`, source: 'images.env' };
 }
 
 /**
  * Read and resolve in one step. The only impure function in this module, and it
- * touches exactly one file: a missing `deploy/images.env` is the fallback path,
- * not a crash, so a user who downloaded a binary without the repository still
- * gets a working default.
+ * touches exactly one file.
+ *
+ * A missing `deploy/images.env` is `'unresolved'`, not a crash and not a
+ * default: a user who unpacked a release tarball without that file has no pin,
+ * and telling them so (naming the override) is the only honest answer. The
+ * override is still consulted first, so it works with no file at all.
  */
-export async function readAndResolveDesktopImage(imagesEnvPath: string): Promise<ResolvedImage> {
+export async function readAndResolveDesktopImage(
+    imagesEnvPath: string,
+    env: Record<string, string | undefined> = process.env,
+): Promise<ResolvedImage> {
     let text: string;
     try {
         text = await Bun.file(imagesEnvPath).text();
     } catch {
-        return { ref: LOCAL_DESKTOP_IMAGE_FALLBACK, source: 'fallback', reason: `images_env_unreadable: ${imagesEnvPath}` };
+        // The override alone can still resolve this, so ask the resolver with
+        // no entries rather than returning early.
+        const fromEnv = resolveDesktopImage({}, env);
+        if (fromEnv.source === 'override') return fromEnv;
+        return { ref: '', source: 'unresolved', reason: `images_env_unreadable: ${imagesEnvPath} — ${overrideHint()}` };
     }
-    return resolveDesktopImage(parseImagesEnv(text));
+    return resolveDesktopImage(parseImagesEnv(text), env);
 }
 
 // ── argv builders ────────────────────────────────────────────────────────────

--- a/local/src/doctor.ts
+++ b/local/src/doctor.ts
@@ -43,10 +43,13 @@ import { join } from 'node:path';
 
 import { ENV_KEYS, loadConfig, type Env, type LocalConfig } from './config.ts';
 import {
+    DESKTOP_IMAGE_OVERRIDE_ENV,
+    IMAGES_ENV_RELATIVE_PATH,
     NEKO_IMPLICIT_HOSTING_ENV,
     buildContainerEnv,
     buildDockerImageInspectArgv,
     buildDockerVersionArgv,
+    isResolved,
     offsetPortMap,
     type PublishedPort,
 } from './container/run-spec.ts';
@@ -144,25 +147,59 @@ export async function runDoctor(deps: DoctorDeps): Promise<DoctorReport> {
     }
 
     // ── 3. The image ─────────────────────────────────────────────────────────
-    // Through `config.desktopImage`, which is `deploy/images.env` resolved by
-    // T0's own parser — including the documented fallback to the locally-built
-    // reference when the file still carries its placeholder tag. Asking about
-    // any other string would be asking about an image that will not be run.
+    // Through `config.desktopImage`, which is `deploy/images.env`'s pin
+    // resolved by T0's own parser, or the `EZIL_LAUNCHER_IMAGE` override that
+    // beats it. Asking about any other string would be asking about an image
+    // that will not be run.
+    //
+    // 🔴 THE SOURCE IS PART OF THE ANSWER, NOT DECORATION. Until row I0c an
+    // unusable pin was silently replaced by a locally-built literal, so this
+    // line read PASS while the pinned configuration was doing nothing at all.
+    // Every outcome below therefore names WHERE the reference came from —
+    // `deploy/images.env` or the override — and an unresolvable one is a FAIL
+    // before anything is inspected, never a quiet substitution.
     const image = deps.config.desktopImage;
-    const imageWhy = `${image.ref} (${image.source}${image.reason ? `: ${image.reason}` : ''})`;
-    if (!daemonUp) {
+    const sourceLine = image.source === 'override'
+        ? `${DESKTOP_IMAGE_OVERRIDE_ENV} (environment override; ${IMAGES_ENV_RELATIVE_PATH}'s pin is NOT in use)`
+        : image.source === 'images.env'
+            ? `${IMAGES_ENV_RELATIVE_PATH} (the pinned EZIL_DESKTOP_IMAGE:EZIL_DESKTOP_TAG)`
+            : 'nothing usable';
+    const imageWhy = `${image.ref} — source: ${sourceLine}`;
+    // The one sentence that turns "this box cannot pull it" into a fix. The
+    // GHCR package is PRIVATE until the founder changes its visibility, so
+    // "just pull it" is not advice a developer here can act on.
+    const overrideFix = `set ${DESKTOP_IMAGE_OVERRIDE_ENV}=<image:tag> to run an image you already have`
+        + ` (\`docker images\` lists them; the same variable \`deploy/launcher/ezil-os.sh\` reads,`
+        + ' so the launcher pulls and the host runs the same thing)';
+    if (!isResolved(image)) {
+        // Reported without asking the daemon anything: there is no reference to
+        // ask about. This fires before the daemon check matters, and it names
+        // both fixes — the override for a developer, the write-back rule for
+        // whoever broke the pin.
+        add(
+            'desktop image',
+            'FAIL',
+            `no desktop image could be resolved (${image.reason ?? 'no reason recorded'}).`
+            + ` Nothing will start until this is fixed: ${overrideFix}`,
+        );
+    } else if (!daemonUp) {
         add('desktop image', 'FAIL', `cannot look for ${imageWhy} — the daemon is not answering (see above)`);
     } else {
         try {
             const res = await deps.spawn(buildDockerImageInspectArgv(image.ref), { timeoutMs: DOCTOR_DOCKER_TIMEOUT_MS });
             if (res.exitCode === 0 && res.stdout.trim() !== '') {
-                add('desktop image', 'PASS', `${imageWhy} present as ${res.stdout.trim().slice(0, 19)}…`);
+                add('desktop image', 'PASS', `${imageWhy} — present as ${res.stdout.trim().slice(0, 19)}…`);
             } else {
                 add(
                     'desktop image',
                     'FAIL',
-                    `${imageWhy} is not present locally — build it with \`cd worker && docker build -t ${image.ref} .\``
-                    + `, or \`docker pull ${image.ref}\` once it is published`,
+                    `${imageWhy} — NOT present locally.`
+                    + ` Fix it one of three ways: \`docker pull ${image.ref}\``
+                    + (image.ref.startsWith('ghcr.io/ezilhq/')
+                        ? ' (the GHCR package is PRIVATE until it is made public, so this needs `docker login ghcr.io`'
+                          + ' with a token carrying `read:packages`)'
+                        : '')
+                    + `; \`cd worker && docker build -t ${image.ref} .\`; or ${overrideFix}`,
                 );
             }
         } catch (err) {

--- a/local/src/doctor.ts
+++ b/local/src/doctor.ts
@@ -176,11 +176,16 @@ export async function runDoctor(deps: DoctorDeps): Promise<DoctorReport> {
         // ask about. This fires before the daemon check matters, and it names
         // both fixes — the override for a developer, the write-back rule for
         // whoever broke the pin.
+        const why = image.reason ?? 'no reason recorded';
         add(
             'desktop image',
             'FAIL',
-            `no desktop image could be resolved (${image.reason ?? 'no reason recorded'}).`
-            + ` Nothing will start until this is fixed: ${overrideFix}`,
+            `no desktop image could be resolved — nothing will start until this is fixed. ${why}`
+            // The resolver's own reasons already end by naming the override;
+            // appending it again would say the same sentence twice. A reason
+            // that does NOT name it still gets the fix, so this branch can
+            // never leave a user without one.
+            + (why.includes(DESKTOP_IMAGE_OVERRIDE_ENV) ? '' : `. ${overrideFix}`),
         );
     } else if (!daemonUp) {
         add('desktop image', 'FAIL', `cannot look for ${imageWhy} — the daemon is not answering (see above)`);

--- a/local/tests/doctor.test.ts
+++ b/local/tests/doctor.test.ts
@@ -197,6 +197,15 @@ describe('the desktop image', () => {
         const detail = find(report.checks, 'desktop image').detail;
         expect(detail).toContain('images_env_bad_tag');
         expect(detail).toContain('EZIL_LAUNCHER_IMAGE=<image:tag>');
+        // The fix is named ONCE, not twice: this reason already carries it, so
+        // the doctor must not append its own copy.
+        expect(detail.split('EZIL_LAUNCHER_IMAGE=<image:tag>').length - 1).toBe(1);
+        // Positive control for that de-duplication — a reason that does NOT
+        // name the override still gets the fix appended.
+        const bare = await runDoctor(healthyDeps({
+            config: fakeConfig({ desktopImage: { ref: '', source: 'unresolved', reason: 'images_env_incomplete' } }),
+        }));
+        expect(find(bare.checks, 'desktop image').detail).toContain('EZIL_LAUNCHER_IMAGE=<image:tag>');
         // Nothing was inspected: `docker image inspect ''` is never issued.
         expect(inspected.some((argv) => argv.includes('inspect'))).toBe(false);
         // Positive control: the healthy fixture DOES inspect.

--- a/local/tests/doctor.test.ts
+++ b/local/tests/doctor.test.ts
@@ -48,7 +48,11 @@ function fakeConfig(overrides: Partial<LocalConfig> = {}): LocalConfig {
         telemetryPath: '/x/state/telemetry.ndjson',
         shellAssetsDir: '/x/app/public/os',
         shellAssetsSearched: ['/x/app/public/os'],
-        desktopImage: { ref: 'ezil-os-worker-sandbox:ff199202', source: 'fallback', reason: 'images_env_bad_tag' },
+        // The default fixture is a HEALTHY resolution. Before row I0c it was
+        // `source: 'fallback'` — a state the resolver can no longer produce:
+        // an unusable pin is now `'unresolved'` with an empty `ref`, and the
+        // two cases below drive that branch on purpose.
+        desktopImage: { ref: 'ezil-os-worker-sandbox:ff199202', source: 'override' },
         mcpEndpoint: null,
         appUrl: null,
         hostPortOffset: 0,
@@ -157,14 +161,66 @@ describe('the docker daemon', () => {
 });
 
 describe('the desktop image', () => {
-    it('FAILS with the build command when the image is absent', async () => {
+    it('FAILS with the build command AND the override when the image is absent', async () => {
         const report = await runDoctor(healthyDeps({
             spawn: async (argv) => (argv[0] === 'version'
                 ? OK
                 : { exitCode: 1, stdout: '', stderr: 'Error: No such image', timedOut: false }),
         }));
         expect(statusOf(report.checks, 'desktop image')).toBe('desktop image: FAIL');
-        expect(find(report.checks, 'desktop image').detail).toContain('docker build -t ezil-os-worker-sandbox:ff199202');
+        const detail = find(report.checks, 'desktop image').detail;
+        expect(detail).toContain('docker build -t ezil-os-worker-sandbox:ff199202');
+        // 🔴 THE FIX A DEVELOPER ON THIS BOX CAN ACTUALLY ACT ON. The pinned
+        // reference lives in a PRIVATE GHCR package, so "pull it" is not advice
+        // that works for everyone; the override is.
+        expect(detail).toContain('EZIL_LAUNCHER_IMAGE=<image:tag>');
+    });
+
+    // 🔴 THE PIN'S OWN FAILURE, WHICH IS DIFFERENT FROM THE IMAGE BEING ABSENT.
+    // Row I0c's headline: an unusable pin used to be replaced by a literal and
+    // this line read PASS. It now FAILS before the daemon is asked anything —
+    // there is no reference to ask about — and names both ways out.
+    it('FAILS on an UNRESOLVED image without inspecting anything, naming the override', async () => {
+        const inspected: string[][] = [];
+        const report = await runDoctor(healthyDeps({
+            config: fakeConfig({
+                desktopImage: {
+                    ref: '',
+                    source: 'unresolved',
+                    reason: "images_env_bad_tag: '<to be pinned by CI>' is not [A-Za-z0-9_][A-Za-z0-9._-]{0,127}"
+                        + ' — set EZIL_LAUNCHER_IMAGE=<image:tag> to run an image you already have',
+                },
+            }),
+            spawn: async (argv) => { inspected.push([...argv]); return argv[0] === 'version' ? OK : IMAGE_OK; },
+        }));
+        expect(statusOf(report.checks, 'desktop image')).toBe('desktop image: FAIL');
+        const detail = find(report.checks, 'desktop image').detail;
+        expect(detail).toContain('images_env_bad_tag');
+        expect(detail).toContain('EZIL_LAUNCHER_IMAGE=<image:tag>');
+        // Nothing was inspected: `docker image inspect ''` is never issued.
+        expect(inspected.some((argv) => argv.includes('inspect'))).toBe(false);
+        // Positive control: the healthy fixture DOES inspect.
+        const ok: string[][] = [];
+        await runDoctor(healthyDeps({
+            spawn: async (argv) => { ok.push([...argv]); return argv[0] === 'version' ? OK : IMAGE_OK; },
+        }));
+        expect(ok.some((argv) => argv.includes('inspect'))).toBe(true);
+    });
+
+    it('names WHERE the reference came from — images.env or the override', async () => {
+        const pinned = await runDoctor(healthyDeps({
+            config: fakeConfig({ desktopImage: { ref: 'ghcr.io/ezilhq/ezil-os-desktop:3c76d43b', source: 'images.env' } }),
+        }));
+        const pinnedDetail = find(pinned.checks, 'desktop image').detail;
+        expect(pinnedDetail).toContain('source: deploy/images.env');
+        expect(pinnedDetail).not.toContain('EZIL_LAUNCHER_IMAGE (environment override');
+
+        const overridden = await runDoctor(healthyDeps({
+            config: fakeConfig({ desktopImage: { ref: 'ezil-os-worker-sandbox:ff199202', source: 'override' } }),
+        }));
+        const overriddenDetail = find(overridden.checks, 'desktop image').detail;
+        expect(overriddenDetail).toContain('source: EZIL_LAUNCHER_IMAGE (environment override');
+        expect(overriddenDetail).toContain("deploy/images.env's pin is NOT in use");
     });
 
     it('asks about the reference the CONFIG resolved, not a constant', async () => {


### PR DESCRIPTION
Row I0c of round INTAKE. `deploy/images.env` carried `EZIL_DESKTOP_TAG=<to be pinned by CI>` — a value that looks like configuration and is not one. Local mode only started because `resolveDesktopImage` silently fell back to a hard-coded literal, and the `local` CI job pulled `:latest` and re-tagged it to that literal, so the job that claims to test the pin never used it.

- `EZIL_DESKTOP_TAG=3c76d43b`, the sha8 published by image.yml run 33876458193.
- One override, one meaning: `EZIL_LAUNCHER_IMAGE` (the name the launcher already reads) overrides the pin; the doctor prints the image's **source** either way. The silent fallback is gone — without the override the doctor FAILS and names three fixes, including that the GHCR package is private.
- The `local` CI job pulls the pinned reference read out of `deploy/images.env`, not `latest`.
- `/app` and `/worker` move to Dependabot's `bun` ecosystem (they have `bun.lock` and CI installs `--frozen-lockfile`; that mismatch is why PR #5 was unmergeable). `/worker/sidecar` stays `npm` — no lockfile.

Measured: doctor without the override → `11 pass, 2 warn, 1 fail` naming the pinned reference and the fix; with it → `12 pass, 2 warn, 0 fail` saying the pin is not in use; `bun test local/` 310 pass / 7 skip (browser suites, Playwright unset) / 0 fail; no container left running. The `local (typecheck + unit + smoke)` job on this PR is the real proof and is not a required context — read its log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)