### PR TITLE
tools: a deterministic triage pass over pull requests and issues (row I5)

### DIFF
--- a/artifacts/runs/wf-os-2026-09-04/I5.json
+++ b/artifacts/runs/wf-os-2026-09-04/I5.json
@@ -1,10 +1,10 @@
 {
   "taskId": "I5",
   "runId": "wf-os-2026-09-04",
-  "status": "running",
+  "status": "done",
   "doneRung": "INDEPENDENT_TEST_PASS",
-  "evidence": "started: worktree task/I5 at 5925edc; measured live repo EZiLHQ/ezil-os — ruleset 22265548 has exactly 15 required contexts; container (real image)/local (typecheck + unit + smoke)/Vercel are NOT among them; DCO rule read from .github/workflows/dco.yml (bot-skip-first, merge-skip, name exact + email case-insensitive); area labels = the ten labeler.yml path labels. Building tools/triage.ts + tests + fixtures.",
+  "evidence": "tools/triage.ts (deterministic triage) + tools/triage.test.ts + 6 fixtures. ./tools/test.sh tools = 136 pass / 0 fail / 0 skip across 3 files (typecheck clean); triage.test.ts alone = 60 pass / 0 fail, 196 expect() calls. Mutation-proof: isGreenOnMain made to ignore mainChecks -> 2 red (ci-flaky cases become ci-red), restored -> 136 pass; permanent regression form classifyChecks(flaky, []) -> ci-red. Live DRY run against EZiLHQ/ezil-os: 2 open PRs (#33/#34, both Dependabot), both not-required-red (Vercel red) + ready-for-review, size/S and size/M would be added, 0 issues; requiredContextsDrift=null (the 15-context constant exactly matches ruleset 22265548 live). No cursor written by the dry run (cursor is ~/.cache, outside the repo); git status clean. Independent leg: the PR's required `tools (typecheck + unit)` context runs this suite on the runner; auto-merge gates on it.",
   "startedAt": "2026-09-05T00:00:00Z",
-  "updatedAt": "2026-09-05T00:00:00Z",
-  "notes": "Deterministic triage over open PRs/issues. Dry-run by default; --post never run by this worker (first post is a supervisor decision)."
+  "updatedAt": "2026-09-05T01:40:00Z",
+  "notes": "Deviations from the brief, all reported: (1) the brief's expected live state (three open PRs incl. a flaky shell leg) is gone — #31/#32 merged, #24's flake is history; the two open PRs are Dependabot with only Vercel red. The flaky proof lives in the fixtures (anchored to the measured #24/#31 shell pattern) + the mutation-proof, not the live run. (2) template-incomplete is SUPPRESSED for bot authors (the brief's rule is unconditional) — commenting 'fill the template' on every dep bump is the noise the marker design exists to prevent; both sides unit-tested. (3) findings set follows the brief (adds not-required-red + draft, drops the plan's needs-prereq). NEVER ran --post. Shared contract: templates link CONTRIBUTING anchors #sign-off-dco (live), #reading-ci / #pr-size / #how-to-send-a-pr (created by row I1) — a slug mismatch is a live-link bug tests cannot catch."
 }

--- a/artifacts/runs/wf-os-2026-09-04/I5.json
+++ b/artifacts/runs/wf-os-2026-09-04/I5.json
@@ -1,0 +1,10 @@
+{
+  "taskId": "I5",
+  "runId": "wf-os-2026-09-04",
+  "status": "running",
+  "doneRung": "INDEPENDENT_TEST_PASS",
+  "evidence": "started: worktree task/I5 at 5925edc; measured live repo EZiLHQ/ezil-os — ruleset 22265548 has exactly 15 required contexts; container (real image)/local (typecheck + unit + smoke)/Vercel are NOT among them; DCO rule read from .github/workflows/dco.yml (bot-skip-first, merge-skip, name exact + email case-insensitive); area labels = the ten labeler.yml path labels. Building tools/triage.ts + tests + fixtures.",
+  "startedAt": "2026-09-05T00:00:00Z",
+  "updatedAt": "2026-09-05T00:00:00Z",
+  "notes": "Deterministic triage over open PRs/issues. Dry-run by default; --post never run by this worker (first post is a supervisor decision)."
+}

--- a/tools/fixtures/triage/issue-list.json
+++ b/tools/fixtures/triage/issue-list.json
@@ -1,0 +1,30 @@
+[
+  {
+    "number": 201,
+    "title": "Files app hangs on a large workspace",
+    "labels": [],
+    "body": "Opening a workspace with many files freezes the desktop.",
+    "updatedAt": "2026-09-05T08:00:00Z"
+  },
+  {
+    "number": 202,
+    "title": "Add GPU passthrough on Linux",
+    "labels": [{ "name": "local" }, { "name": "help wanted" }],
+    "body": "Pass --gpus through to the container.",
+    "updatedAt": "2026-09-05T08:30:00Z"
+  },
+  {
+    "number": 203,
+    "title": "Broken link in the README",
+    "labels": [{ "name": "needs-triage" }],
+    "body": "The docs link 404s.",
+    "updatedAt": "2026-09-05T09:00:00Z"
+  },
+  {
+    "number": 204,
+    "title": "Question about the licence of a vendored library",
+    "labels": [{ "name": "question" }],
+    "body": "Is MIT compatible with AGPL here?",
+    "updatedAt": "2026-09-05T09:30:00Z"
+  }
+]

--- a/tools/fixtures/triage/main-checks.json
+++ b/tools/fixtures/triage/main-checks.json
@@ -1,0 +1,22 @@
+{
+  "total_count": 17,
+  "check_runs": [
+    { "name": "worker (typecheck + unit) (ubuntu-latest)", "status": "completed", "conclusion": "success" },
+    { "name": "worker (typecheck + unit) (windows-latest)", "status": "completed", "conclusion": "success" },
+    { "name": "worker (typecheck + unit) (macos-latest)", "status": "completed", "conclusion": "success" },
+    { "name": "app (typecheck + unit) (ubuntu-latest)", "status": "completed", "conclusion": "success" },
+    { "name": "app (typecheck + unit) (windows-latest)", "status": "completed", "conclusion": "success" },
+    { "name": "app (typecheck + unit) (macos-latest)", "status": "completed", "conclusion": "success" },
+    { "name": "sdk + mcp (typecheck + unit) (ubuntu-latest)", "status": "completed", "conclusion": "success" },
+    { "name": "sdk + mcp (typecheck + unit) (windows-latest)", "status": "completed", "conclusion": "success" },
+    { "name": "sdk + mcp (typecheck + unit) (macos-latest)", "status": "completed", "conclusion": "success" },
+    { "name": "shell (bundle check + browser suites) (ubuntu-latest)", "status": "completed", "conclusion": "success" },
+    { "name": "shell (bundle check + browser suites) (windows-latest)", "status": "completed", "conclusion": "success" },
+    { "name": "shell (bundle check + browser suites) (macos-latest)", "status": "completed", "conclusion": "success" },
+    { "name": "tools (typecheck + unit)", "status": "completed", "conclusion": "success" },
+    { "name": "DCO", "status": "completed", "conclusion": "success" },
+    { "name": "CodeQL (javascript-typescript)", "status": "completed", "conclusion": "success" },
+    { "name": "container (real image)", "status": "completed", "conclusion": "success" },
+    { "name": "local (typecheck + unit + smoke)", "status": "completed", "conclusion": "success" }
+  ]
+}

--- a/tools/fixtures/triage/pr-checks-flaky.json
+++ b/tools/fixtures/triage/pr-checks-flaky.json
@@ -1,0 +1,16 @@
+[
+  { "name": "shell (bundle check + browser suites) (ubuntu-latest)", "bucket": "fail", "state": "FAILURE" },
+  { "name": "shell (bundle check + browser suites) (windows-latest)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "shell (bundle check + browser suites) (macos-latest)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "worker (typecheck + unit) (ubuntu-latest)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "app (typecheck + unit) (ubuntu-latest)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "sdk + mcp (typecheck + unit) (ubuntu-latest)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "tools (typecheck + unit)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "DCO", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "CodeQL (javascript-typescript)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "container (real image)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "local (typecheck + unit + smoke)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "Vercel", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "Vercel Preview Comments", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "label", "bucket": "pass", "state": "SUCCESS" }
+]

--- a/tools/fixtures/triage/pr-checks-red.json
+++ b/tools/fixtures/triage/pr-checks-red.json
@@ -1,0 +1,16 @@
+[
+  { "name": "app (typecheck + unit) (ubuntu-latest)", "bucket": "fail", "state": "FAILURE" },
+  { "name": "app (typecheck + unit) (windows-latest)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "app (typecheck + unit) (macos-latest)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "worker (typecheck + unit) (ubuntu-latest)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "sdk + mcp (typecheck + unit) (ubuntu-latest)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "shell (bundle check + browser suites) (ubuntu-latest)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "tools (typecheck + unit)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "DCO", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "CodeQL (javascript-typescript)", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "container (real image)", "bucket": "fail", "state": "FAILURE" },
+  { "name": "local (typecheck + unit + smoke)", "bucket": "fail", "state": "FAILURE" },
+  { "name": "Vercel", "bucket": "fail", "state": "FAILURE" },
+  { "name": "Vercel Preview Comments", "bucket": "pass", "state": "SUCCESS" },
+  { "name": "label", "bucket": "pass", "state": "SUCCESS" }
+]

--- a/tools/fixtures/triage/pr-commits-unsigned.json
+++ b/tools/fixtures/triage/pr-commits-unsigned.json
@@ -1,0 +1,68 @@
+[
+  {
+    "sha": "b0d4721dbotdependabot0000000000000000000",
+    "commit": {
+      "message": "chore(deps-dev): bump wrangler in /worker in the patch-and-minor group\n\nSigned-off-by: dependabot[bot] <support@github.com>",
+      "author": { "name": "dependabot[bot]", "email": "49699333+dependabot[bot]@users.noreply.github.com", "date": "2026-09-04T20:00:00Z" }
+    },
+    "author": { "login": "dependabot[bot]" },
+    "parents": [{ "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }]
+  },
+  {
+    "sha": "1111111111111111111111111111111111111111",
+    "commit": {
+      "message": "feat: add a thing\n\nSigned-off-by: Jane Doe <jane@example.com>",
+      "author": { "name": "Jane Doe", "email": "jane@example.com", "date": "2026-09-04T21:00:00Z" }
+    },
+    "author": { "login": "janedoe" },
+    "parents": [{ "sha": "1111111111111111111111111111111111111110" }]
+  },
+  {
+    "sha": "2222222222222222222222222222222222222222",
+    "commit": {
+      "message": "fix: forgot to sign this one",
+      "author": { "name": "Alex Kim", "email": "alex@example.com", "date": "2026-09-04T22:00:00Z" }
+    },
+    "author": { "login": "alexkim" },
+    "parents": [{ "sha": "2222222222222222222222222222222222222221" }]
+  },
+  {
+    "sha": "3333333333333333333333333333333333333333",
+    "commit": {
+      "message": "refactor: rename a symbol\n\nSigned-off-by: Sam Lee <sam@old.example.com>",
+      "author": { "name": "Sam Lee", "email": "sam@new.example.com", "date": "2026-09-04T23:00:00Z" }
+    },
+    "author": { "login": "samlee" },
+    "parents": [{ "sha": "3333333333333333333333333333333333333331" }]
+  },
+  {
+    "sha": "4444444444444444444444444444444444444444",
+    "commit": {
+      "message": "Merge branch 'main' into feature",
+      "author": { "name": "Alex Kim", "email": "alex@example.com", "date": "2026-09-05T00:00:00Z" }
+    },
+    "author": { "login": "alexkim" },
+    "parents": [
+      { "sha": "4444444444444444444444444444444444444441" },
+      { "sha": "4444444444444444444444444444444444444442" }
+    ]
+  },
+  {
+    "sha": "5555555555555555555555555555555555555555",
+    "commit": {
+      "message": "docs: tweak wording\n\nSigned-off-by: Case User <case@example.com>",
+      "author": { "name": "Case User", "email": "Case@Example.COM", "date": "2026-09-05T01:00:00Z" }
+    },
+    "author": { "login": "caseuser" },
+    "parents": [{ "sha": "5555555555555555555555555555555555555551" }]
+  },
+  {
+    "sha": "6666666666666666666666666666666666666666",
+    "commit": {
+      "message": "chore: small change\n\nSigned-off-by: Bob <bob@x.com>",
+      "author": { "name": "bob", "email": "bob@x.com", "date": "2026-09-05T02:00:00Z" }
+    },
+    "author": { "login": "bob" },
+    "parents": [{ "sha": "6666666666666666666666666666666666666661" }]
+  }
+]

--- a/tools/fixtures/triage/pr-list.json
+++ b/tools/fixtures/triage/pr-list.json
@@ -1,0 +1,62 @@
+[
+  {
+    "number": 33,
+    "title": "chore(deps-dev): bump wrangler from 4.108.0 to 4.128.0 in /worker in the patch-and-minor group",
+    "author": { "login": "app/dependabot", "is_bot": true },
+    "isDraft": false,
+    "labels": [{ "name": "worker" }, { "name": "dependencies" }],
+    "additions": 40,
+    "deletions": 36,
+    "headRefName": "dependabot/bun/worker/patch-and-minor-90741ce0a8",
+    "body": "Bumps the patch-and-minor group in /worker with 1 update: wrangler. Updates `wrangler` from 4.108.0 to 4.128.0.",
+    "updatedAt": "2026-09-04T20:26:43Z"
+  },
+  {
+    "number": 34,
+    "title": "chore(deps): bump the patch-and-minor group in /app with 11 updates",
+    "author": { "login": "app/dependabot", "is_bot": true },
+    "isDraft": false,
+    "labels": [{ "name": "app" }, { "name": "dependencies" }],
+    "additions": 181,
+    "deletions": 115,
+    "headRefName": "dependabot/bun/app/patch-and-minor-3f2a1c",
+    "body": "Bumps the patch-and-minor group in /app with 11 updates.",
+    "updatedAt": "2026-09-04T20:28:23Z"
+  },
+  {
+    "number": 101,
+    "title": "feat: big refactor of the boot pipeline",
+    "author": { "login": "alice", "is_bot": false },
+    "isDraft": true,
+    "labels": [{ "name": "shell" }],
+    "additions": 1200,
+    "deletions": 300,
+    "headRefName": "feat/boot-refactor",
+    "body": "This reworks a lot of the boot pipeline. TODO: write this up properly.",
+    "updatedAt": "2026-09-05T09:00:00Z"
+  },
+  {
+    "number": 102,
+    "title": "fix: focus order in the window manager",
+    "author": { "login": "bob", "is_bot": false },
+    "isDraft": false,
+    "labels": [{ "name": "shell" }, { "name": "size/L" }],
+    "additions": 120,
+    "deletions": 80,
+    "headRefName": "fix/focus-order",
+    "body": "## What changed\n\nFixes the focus/z-order bug when two windows open together.\n\n- [x] I have read CONTRIBUTING.md\n- [x] I ran `./tools/test.sh shell`\n- [ ] Every commit is signed off",
+    "updatedAt": "2026-09-05T10:00:00Z"
+  },
+  {
+    "number": 103,
+    "title": "docs: fix a typo in the README",
+    "author": { "login": "carol", "is_bot": false },
+    "isDraft": false,
+    "labels": [{ "name": "docs" }],
+    "additions": 3,
+    "deletions": 1,
+    "headRefName": "docs/readme-typo",
+    "body": "A tiny fix.\n\n- [x] I have read CONTRIBUTING.md",
+    "updatedAt": "2026-09-05T11:00:00Z"
+  }
+]

--- a/tools/triage.test.ts
+++ b/tools/triage.test.ts
@@ -1,0 +1,601 @@
+/**
+ * Tests for the deterministic triage core.
+ *
+ * ## Fixture provenance (a `gh` upgrade can invalidate these)
+ *
+ * All shapes are captured from real `gh` output on `EZiLHQ/ezil-os` (2026-09-05):
+ *   - `main-checks.json`  — the real `gh api repos/EZiLHQ/ezil-os/commits/main/check-runs`
+ *     response, trimmed to the fifteen required contexts plus `container`/`local`,
+ *     all `success` (main was green). This is the "green on main" side of the flaky
+ *     discriminator.
+ *   - `pr-list.json`      — PRs #33 and #34 are the real open Dependabot PRs
+ *     (`gh pr list --json ...`); #101/#102/#103 are synthesized to the same shape
+ *     to exercise human-authored findings (draft-XL, ready-M-with-checklist, XS)
+ *     that no currently-open PR happens to show.
+ *   - `pr-checks-*.json`  — the shape of `gh pr checks --json name,bucket,state`.
+ *     The failing legs are set to the MEASURED flake pattern: PRs #24/#31 carried a
+ *     genuinely flaky `shell (…)` leg that was green on `main` for the same name
+ *     (round INTAKE §B3 correction 1). `pr-checks-red.json` additionally carries the
+ *     `container`/`local`/`Vercel` reds that a fork PR always shows.
+ *   - `pr-commits-unsigned.json` — the `gh api repos/.../pulls/{n}/commits` shape.
+ *     Commit #1 is the real Dependabot ident (name `dependabot[bot]`, a
+ *     `@users.noreply.github.com` email) carrying a `Signed-off-by` whose email is
+ *     `support@github.com` — the exact mismatch `dco.yml` documents, which MUST be
+ *     bot-skipped rather than failed.
+ *
+ * The classifiers are pure, so these fixtures are the whole story: the mutation
+ * proof for the flaky discriminator is `classifyChecks(flaky, [])` below, and the
+ * manual version (make `isGreenOnMain` ignore its argument) is recorded in the
+ * row's report.
+ */
+
+import { readFileSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "bun:test";
+
+import {
+	AREA_LABELS,
+	FINDING_ORDER,
+	REQUIRED_CONTEXTS,
+	SIZE_LABELS,
+	TEMPLATES,
+	applyActions,
+	argsFor,
+	buildComment,
+	classifyChecks,
+	classifyPr,
+	findingsToPost,
+	hasChecklist,
+	inScope,
+	isBotAuthor,
+	issueLabelChange,
+	marker,
+	markersIn,
+	normalizeCommits,
+	normalizeMainChecks,
+	normalizePrChecks,
+	parseArgs,
+	parseSignoff,
+	planActions,
+	prLabelChange,
+	readCursor,
+	run,
+	signoffValues,
+	sizeBucket,
+	unsignedCommits,
+	type Action,
+	type Check,
+	type Commit,
+	type Finding,
+	type Issue,
+	type IssueTriage,
+	type PrTriage,
+	type PullRequest,
+} from "./triage.ts";
+
+function fx<T>(name: string): T {
+	return JSON.parse(readFileSync(join(import.meta.dir, "fixtures", "triage", name), "utf8")) as T;
+}
+
+const prList = fx<PullRequest[]>("pr-list.json");
+const issueList = fx<Issue[]>("issue-list.json");
+const mainChecks = normalizeMainChecks(fx("main-checks.json"));
+const flakyChecks = normalizePrChecks(fx("pr-checks-flaky.json"));
+const redChecks = normalizePrChecks(fx("pr-checks-red.json"));
+const commits = normalizeCommits(fx("pr-commits-unsigned.json"));
+
+function pr(number: number): PullRequest {
+	const found = prList.find((p) => p.number === number);
+	if (found === undefined) throw new Error(`fixture pr-list.json has no PR #${number}`);
+	return found;
+}
+
+/** The commits that are skipped or already ok — a PR built from these has no DCO problem. */
+const signedSubset = commits.filter((c) => ["b0d472", "111111", "444444", "555555"].some((p) => c.sha.startsWith(p)));
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("size buckets, at every boundary", () => {
+	it("maps the ranges the brief names", () => {
+		expect(sizeBucket(0)).toBe("XS");
+		expect(sizeBucket(20)).toBe("XS");
+		expect(sizeBucket(21)).toBe("S");
+		expect(sizeBucket(100)).toBe("S");
+		expect(sizeBucket(101)).toBe("M");
+		expect(sizeBucket(400)).toBe("M");
+		expect(sizeBucket(401)).toBe("L");
+		expect(sizeBucket(1000)).toBe("L");
+		expect(sizeBucket(1001)).toBe("XL");
+		expect(sizeBucket(50000)).toBe("XL");
+	});
+});
+
+describe("PR size labels: add the right one, strip the other four", () => {
+	it("adds the computed label when none is present (#33 → size/S)", () => {
+		const change = prLabelChange(pr(33)); // 40 + 36 = 76
+		expect(change.add).toEqual(["size/S"]);
+		expect(change.remove).toEqual([]);
+	});
+
+	it("removes a stale size label and adds the correct one (#102 carries size/L, is 200 → M)", () => {
+		const change = prLabelChange(pr(102)); // 120 + 80 = 200, labels include size/L
+		expect(change.add).toEqual(["size/M"]);
+		expect(change.remove).toEqual(["size/L"]);
+	});
+
+	it("adds nothing when the correct label is already present, and never touches a non-size label", () => {
+		const change = prLabelChange({ additions: 10, deletions: 5, labels: [{ name: "size/XS" }, { name: "shell" }] });
+		expect(change.add).toEqual([]);
+		expect(change.remove).toEqual([]); // shell is not a size label
+	});
+
+	it("every size label it may add is one of the five, and no other", () => {
+		for (const total of [0, 21, 101, 401, 1001]) {
+			const change = prLabelChange({ additions: total, deletions: 0, labels: [] });
+			for (const label of change.add) expect(SIZE_LABELS).toContain(label);
+		}
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("template completeness: a checkbox anywhere means the template is present", () => {
+	it("fires for a human PR whose body has no checkbox", () => {
+		expect(hasChecklist(pr(101).body)).toBe(false);
+		expect(classifyPr(pr(101), [], signedSubset, mainChecks)).toContain("template-incomplete");
+	});
+
+	it("does NOT fire for a human PR that kept the checklist (positive control)", () => {
+		expect(hasChecklist(pr(102).body)).toBe(true);
+		expect(classifyPr(pr(102), [], signedSubset, mainChecks)).not.toContain("template-incomplete");
+	});
+
+	it("is SUPPRESSED for a bot author even with no checkbox — the deviation from the brief's unconditional rule", () => {
+		expect(isBotAuthor(pr(33))).toBe(true);
+		expect(hasChecklist(pr(33).body)).toBe(false);
+		expect(classifyPr(pr(33), [], [], mainChecks)).not.toContain("template-incomplete");
+	});
+
+	it("recognises `*`-bulleted and indented checkboxes too, and rejects prose", () => {
+		expect(hasChecklist("* [ ] a task")).toBe(true);
+		expect(hasChecklist("  - [x] done")).toBe(true);
+		expect(hasChecklist("just a paragraph with [brackets] but no task")).toBe(false);
+		expect(hasChecklist("")).toBe(false);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("draft vs ready-for-review — exactly one always fires", () => {
+	it("draft PR", () => {
+		const findings = classifyPr(pr(101), [], signedSubset, mainChecks);
+		expect(findings).toContain("draft");
+		expect(findings).not.toContain("ready-for-review");
+	});
+
+	it("ready PR", () => {
+		const findings = classifyPr(pr(102), [], signedSubset, mainChecks);
+		expect(findings).toContain("ready-for-review");
+		expect(findings).not.toContain("draft");
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("the check discriminator: not-required-red > ci-flaky > ci-red", () => {
+	it("a required leg red on the PR but green on main is ci-flaky, not ci-red (the #24 case)", () => {
+		const findings = classifyChecks(flakyChecks, mainChecks);
+		expect([...findings]).toEqual(["ci-flaky"]);
+		expect(findings.has("ci-red")).toBe(false);
+	});
+
+	it("MUTATION: the same red leg with no main baseline is ci-red — proving mainChecks is load-bearing", () => {
+		const findings = classifyChecks(flakyChecks, []);
+		expect([...findings]).toEqual(["ci-red"]);
+		expect(findings.has("ci-flaky")).toBe(false);
+	});
+
+	it("a non-required leg red on the PR but green on main is not-required-red, NOT ci-flaky (precedence)", () => {
+		const containerOnly: Check[] = [{ name: "container (real image)", bucket: "fail" }];
+		const findings = classifyChecks(containerOnly, mainChecks); // container IS green on main
+		expect([...findings]).toEqual(["not-required-red"]);
+		expect(findings.has("ci-flaky")).toBe(false);
+	});
+
+	it("positive control: a required leg red-on-PR/green-on-main from the SAME main is ci-flaky", () => {
+		const shellOnly: Check[] = [{ name: "shell (bundle check + browser suites) (ubuntu-latest)", bucket: "fail" }];
+		expect([...classifyChecks(shellOnly, mainChecks)]).toEqual(["ci-flaky"]);
+	});
+
+	it("the fork PR shape: a real required regression is ci-red while container/local/Vercel are not-required-red", () => {
+		// app leg failing on main too (a broken-main scenario) so it is a genuine ci-red, not a flake.
+		const brokenMain = mainChecks.map((c) =>
+			c.name === "app (typecheck + unit) (ubuntu-latest)" ? ({ name: c.name, bucket: "fail" as const }) : c,
+		);
+		const findings = classifyChecks(redChecks, brokenMain);
+		expect([...findings].sort()).toEqual(["ci-red", "not-required-red"]);
+	});
+
+	it("skipping/pending/cancel legs never count as failures (positive control on bucket)", () => {
+		const noisy: Check[] = [
+			{ name: "tools (typecheck + unit)", bucket: "pending" },
+			{ name: "app (typecheck + unit) (macos-latest)", bucket: "skipping" },
+			{ name: "DCO", bucket: "cancel" },
+		];
+		expect([...classifyChecks(noisy, mainChecks)]).toEqual([]);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("DCO — the exact rule from dco.yml", () => {
+	it("flags exactly the two human failures + the case-sensitive-name mismatch, and nothing else", () => {
+		const failures = unsignedCommits(commits);
+		const shas = failures.map((f) => f.sha.slice(0, 6)).sort();
+		expect(shas).toEqual(["222222", "333333", "666666"]);
+	});
+
+	it("distinguishes a missing trailer from a mismatched one", () => {
+		const byPrefix = (p: string) => unsignedCommits(commits).find((f) => f.sha.startsWith(p));
+		expect(byPrefix("222222")?.reason).toBe("no-trailer");
+		expect(byPrefix("333333")?.reason).toBe("mismatch"); // email old vs new
+		expect(byPrefix("666666")?.reason).toBe("mismatch"); // name "Bob" vs author "bob", case-sensitive
+	});
+
+	it("the Dependabot commit with a mismatched trailer email is SKIPPED as a bot, not failed (the dco.yml trap)", () => {
+		const bot = commits.find((c) => c.sha.startsWith("b0d472"));
+		expect(bot?.authorName).toBe("dependabot[bot]");
+		// The trailer email (support@github.com) does not match the author email — an
+		// "is a trailer missing?" gate would fail it. It must be absent from failures.
+		expect(unsignedCommits(commits).some((f) => f.sha.startsWith("b0d472"))).toBe(false);
+	});
+
+	it("a merge commit is skipped even with no trailer (positive control: it is unsigned)", () => {
+		const merge = commits.find((c) => c.sha.startsWith("444444"));
+		expect(merge?.parents).toBe(2);
+		expect(signoffValues(merge?.message ?? "")).toEqual([]);
+		expect(unsignedCommits(commits).some((f) => f.sha.startsWith("444444"))).toBe(false);
+	});
+
+	it("email matches case-insensitively but name matches exactly", () => {
+		const caseOk = commits.find((c) => c.sha.startsWith("555555"));
+		expect(caseOk?.authorEmail).toBe("Case@Example.COM"); // author upper, trailer lower → still ok
+		expect(unsignedCommits(commits).some((f) => f.sha.startsWith("555555"))).toBe(false);
+	});
+
+	it("a correctly-signed set has no failures (positive control that the rule does not reject everything)", () => {
+		expect(unsignedCommits(signedSubset)).toEqual([]);
+	});
+
+	it("missing-dco fires on a PR with any unsigned commit and not on a clean one", () => {
+		expect(classifyPr(pr(102), [], commits, mainChecks)).toContain("missing-dco");
+		expect(classifyPr(pr(102), [], signedSubset, mainChecks)).not.toContain("missing-dco");
+	});
+
+	it("parseSignoff splits Name <email>, and rejects a bare token", () => {
+		expect(parseSignoff("Jane Doe <jane@example.com>")).toEqual({ name: "Jane Doe", email: "jane@example.com" });
+		expect(parseSignoff("not a trailer")).toBeNull();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("classifyPr integration — ordered findings over the fixtures", () => {
+	it("#101 human draft, 1500 lines, no checklist, signed → template-incomplete, size-xl, draft (in order)", () => {
+		expect(classifyPr(pr(101), [], signedSubset, mainChecks)).toEqual(["template-incomplete", "size-xl", "draft"]);
+	});
+
+	it("#33 Dependabot with the flaky shell leg → ci-flaky, ready-for-review (no template, no dco)", () => {
+		const botCommits = commits.filter((c) => c.sha.startsWith("b0d472"));
+		expect(classifyPr(pr(33), flakyChecks, botCommits, mainChecks)).toEqual(["ci-flaky", "ready-for-review"]);
+	});
+
+	it("#102 clean human PR with a checklist and green checks → only ready-for-review", () => {
+		expect(classifyPr(pr(102), [], signedSubset, mainChecks)).toEqual(["ready-for-review"]);
+	});
+
+	it("the returned findings are always a subset of the closed set, in canonical order", () => {
+		const findings = classifyPr(pr(101), redChecks, commits, []);
+		for (const f of findings) expect(FINDING_ORDER as readonly string[]).toContain(f);
+		const positions = findings.map((f) => (FINDING_ORDER as readonly Finding[]).indexOf(f));
+		expect(positions).toEqual([...positions].sort((a, b) => a - b));
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("issue triage: needs-triage iff no area label and not already present", () => {
+	it("fires on an issue with no labels", () => {
+		expect(issueLabelChange(issueList[0]!).add).toEqual(["needs-triage"]);
+	});
+
+	it("does NOT fire when an area label is present (positive control)", () => {
+		expect(issueLabelChange(issueList[1]!).add).toEqual([]); // has "local"
+	});
+
+	it("is idempotent: an issue already carrying needs-triage is not re-added", () => {
+		expect(issueLabelChange(issueList[2]!).add).toEqual([]); // already needs-triage
+	});
+
+	it("a non-area label (question) does not count as an area label", () => {
+		expect(issueLabelChange(issueList[3]!).add).toEqual(["needs-triage"]);
+	});
+
+	it("never removes a label", () => {
+		for (const issue of issueList) expect(issueLabelChange(issue).remove).toEqual([]);
+	});
+
+	it("the area set is exactly the ten path labels", () => {
+		expect([...AREA_LABELS].sort()).toEqual(["app", "ci", "docs", "e2e", "local", "mcp", "sdk", "shell", "tools", "worker"]);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("comment templates are data, asserted verbatim", () => {
+	it("has a body for the six actionable findings and NONE for the two status findings", () => {
+		expect(Object.keys(TEMPLATES).sort()).toEqual([
+			"ci-flaky",
+			"ci-red",
+			"missing-dco",
+			"not-required-red",
+			"size-xl",
+			"template-incomplete",
+		]);
+		expect("draft" in TEMPLATES).toBe(false);
+		expect("ready-for-review" in TEMPLATES).toBe(false);
+	});
+
+	it("missing-dco gives both remedies, force-with-lease, and the #sign-off-dco anchor", () => {
+		const body = TEMPLATES["missing-dco"];
+		expect(body).toContain("git commit --amend -s");
+		expect(body).toContain("git rebase --signoff <base>");
+		expect(body).toContain("git push --force-with-lease");
+		expect(body).toContain("CONTRIBUTING.md#sign-off-dco");
+	});
+
+	it("not-required-red explains fork/GHCR, cites ci.yml:62-72, and ends with the mandated sentence", () => {
+		const body = TEMPLATES["not-required-red"];
+		expect(body).toContain("container (real image)");
+		expect(body).toContain("local (typecheck + unit + smoke)");
+		expect(body).toContain("private GitHub Container Registry");
+		expect(body).toContain(".github/workflows/ci.yml#L62-L72");
+		expect(body.endsWith("Neither is one of the fifteen required contexts, so this does not block your merge.")).toBe(true);
+	});
+
+	it("ci-flaky says known flake, not your change, maintainer re-run", () => {
+		const body = TEMPLATES["ci-flaky"];
+		expect(body).toContain("known-flaky");
+		expect(body).toContain("not your change");
+		expect(body).toContain("re-run");
+	});
+
+	it("each CONTRIBUTING anchor a template links is one of the four this row depends on", () => {
+		const anchors = ["#sign-off-dco", "#how-to-send-a-pr", "#reading-ci", "#pr-size"];
+		expect(TEMPLATES["template-incomplete"]).toContain("#how-to-send-a-pr");
+		expect(TEMPLATES["ci-red"]).toContain("#reading-ci");
+		expect(TEMPLATES["ci-flaky"]).toContain("#reading-ci");
+		expect(TEMPLATES["size-xl"]).toContain("#pr-size");
+		for (const body of Object.values(TEMPLATES)) {
+			const matches = body.match(/CONTRIBUTING\.md(#[a-z-]+)/g) ?? [];
+			for (const m of matches) expect(anchors).toContain(m.replace("CONTRIBUTING.md", ""));
+		}
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("comment assembly and marker idempotence", () => {
+	it("buildComment merges sections, each behind its marker, plus one footer; null when empty", () => {
+		const body = buildComment(["missing-dco", "size-xl", "draft"]);
+		expect(body).not.toBeNull();
+		expect(body!).toContain(marker("missing-dco"));
+		expect(body!).toContain(marker("size-xl"));
+		expect(body!).not.toContain(marker("draft")); // draft is not a comment finding
+		expect(body!).toContain("tools/triage.ts"); // footer
+		expect(buildComment(["draft", "ready-for-review"])).toBeNull(); // status-only → nothing to say
+		expect(buildComment([])).toBeNull();
+	});
+
+	it("markersIn finds the markers a prior comment left", () => {
+		const prior = [`intro\n${marker("missing-dco")}\nbody`, `${marker("ci-flaky")} more`];
+		expect([...markersIn(prior)].sort()).toEqual(["ci-flaky", "missing-dco"]);
+	});
+
+	it("findingsToPost drops a finding whose marker is already present — a second run posts nothing", () => {
+		const findings: Finding[] = ["missing-dco", "size-xl", "ready-for-review"];
+		const firstRun = findingsToPost(findings, new Set());
+		expect(firstRun).toEqual(["missing-dco", "size-xl"]); // ready-for-review has no template
+		expect(buildComment(firstRun)).not.toBeNull();
+
+		const alreadyPosted = markersIn([buildComment(firstRun)!]);
+		const secondRun = findingsToPost(findings, alreadyPosted);
+		expect(secondRun).toEqual([]);
+		expect(buildComment(secondRun)).toBeNull();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("the action plan cannot express destruction", () => {
+	const samplePrs: PrTriage[] = [
+		{
+			number: 1,
+			title: "t",
+			findings: ["missing-dco"],
+			size: "size/M",
+			labelsToAdd: ["size/M"],
+			labelsToRemove: ["size/L"],
+			redChecks: [],
+			wouldPost: "hello",
+		},
+	];
+	const sampleIssues: IssueTriage[] = [
+		{ number: 2, title: "i", findings: ["needs-triage"], labelsToAdd: ["needs-triage"], labelsToRemove: [], wouldPost: null },
+	];
+
+	it("planActions emits only comment / add-label / remove-label", () => {
+		const actions = planActions(samplePrs, sampleIssues);
+		for (const a of actions) expect(["comment", "add-label", "remove-label"]).toContain(a.kind);
+		expect(actions.map((a) => a.kind)).toEqual(["comment", "add-label", "remove-label", "add-label"]);
+	});
+
+	it("argsFor only ever calls `pr`/`issue` with `comment`/`edit` — never close/merge/ready/review/rerun", () => {
+		const actions = planActions(samplePrs, sampleIssues);
+		const forbidden = ["close", "merge", "ready", "review", "rerun", "delete", "--delete", "reopen"];
+		for (const a of actions) {
+			const args = argsFor(a, "EZiLHQ/ezil-os");
+			expect(["pr", "issue"]).toContain(args[0]!);
+			expect(["comment", "edit"]).toContain(args[1]!);
+			for (const token of args) expect(forbidden).not.toContain(token);
+		}
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("the dry-run write gate", () => {
+	const actions: Action[] = [
+		{ kind: "comment", target: "pr", number: 1, body: "x" },
+		{ kind: "add-label", target: "pr", number: 1, label: "size/M" },
+	];
+
+	it("post:false invokes gh zero times", async () => {
+		const calls: string[][] = [];
+		await applyActions(actions, { post: false, repo: "r", run: async (a) => void calls.push(a) });
+		expect(calls.length).toBe(0);
+	});
+
+	it("post:true invokes gh exactly once per action, with the argsFor vector", async () => {
+		const calls: string[][] = [];
+		await applyActions(actions, { post: true, repo: "r", run: async (a) => void calls.push(a) });
+		expect(calls.length).toBe(2);
+		expect(calls[0]).toEqual(argsFor(actions[0]!, "r"));
+		expect(calls[1]).toEqual(argsFor(actions[1]!, "r"));
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("normalisers reject a broken shape rather than mis-reading it", () => {
+	it("normalizePrChecks reads name+bucket", () => {
+		expect(flakyChecks.find((c) => c.name === "DCO")?.bucket).toBe("pass");
+		expect(flakyChecks.find((c) => c.name.startsWith("shell"))?.bucket).toBe("fail");
+	});
+
+	it("normalizePrChecks throws on an unknown bucket (positive control: a known one passes)", () => {
+		expect(normalizePrChecks([{ name: "x", bucket: "pass" }])).toEqual([{ name: "x", bucket: "pass" }]);
+		expect(() => normalizePrChecks([{ name: "x", bucket: "greenish" }])).toThrow(/unrecognised check bucket/);
+	});
+
+	it("normalizeMainChecks maps conclusion+status to buckets", () => {
+		expect(mainChecks.every((c) => c.bucket === "pass")).toBe(true);
+		expect(normalizeMainChecks({ check_runs: [{ name: "x", status: "in_progress", conclusion: null }] })[0]!.bucket).toBe(
+			"pending",
+		);
+		expect(normalizeMainChecks({ check_runs: [{ name: "y", status: "completed", conclusion: "failure" }] })[0]!.bucket).toBe(
+			"fail",
+		);
+	});
+
+	it("normalizeCommits counts parents and pulls the git author ident", () => {
+		expect(commits.length).toBe(7);
+		expect(commits.find((c) => c.sha.startsWith("444444"))?.parents).toBe(2);
+		expect(commits.find((c) => c.sha.startsWith("111111"))?.authorEmail).toBe("jane@example.com");
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("the cursor is machine state, and a broken one is loud", () => {
+	it("inScope: a null since is everything; otherwise it is a >= comparison", () => {
+		expect(inScope("2020-01-01T00:00:00Z", null)).toBe(true);
+		expect(inScope("2026-09-05T00:00:00Z", "2026-09-04T00:00:00Z")).toBe(true);
+		expect(inScope("2026-09-03T00:00:00Z", "2026-09-04T00:00:00Z")).toBe(false);
+	});
+
+	it("readCursor returns null for a missing file", () => {
+		expect(readCursor(join(tmpdir(), "definitely-not-here-triage-cursor.json"))).toBeNull();
+	});
+
+	it("readCursor throws on a present-but-invalid cursor rather than collapsing to a first run", () => {
+		const dir = mkdtempSync(join(tmpdir(), "triage-cursor-"));
+		try {
+			const bad = join(dir, "c.json");
+			writeFileSync(bad, "not json at all");
+			expect(() => readCursor(bad)).toThrow(/present but not JSON/);
+			const half = join(dir, "half.json");
+			writeFileSync(half, JSON.stringify({ since: "x" }));
+			expect(() => readCursor(half)).toThrow(/malformed/);
+			const ok = join(dir, "ok.json");
+			writeFileSync(ok, JSON.stringify({ since: "2026-09-04T00:00:00Z", updatedAt: "2026-09-04T00:00:00Z" }));
+			expect(readCursor(ok)?.since).toBe("2026-09-04T00:00:00Z");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("parseArgs", () => {
+	it("defaults to the repo, no since, dry run", () => {
+		expect(parseArgs([])).toEqual({ repo: "EZiLHQ/ezil-os", since: null, post: false, help: false });
+	});
+
+	it("reads --repo, --since, --post", () => {
+		expect(parseArgs(["--repo", "a/b", "--since", "2026-01-01T00:00:00Z", "--post"])).toEqual({
+			repo: "a/b",
+			since: "2026-01-01T00:00:00Z",
+			post: true,
+			help: false,
+		});
+	});
+
+	it("refuses an unknown flag and a value-less option", () => {
+		expect(() => parseArgs(["--wat"])).toThrow(/unknown argument/);
+		expect(() => parseArgs(["--repo"])).toThrow(/--repo needs/);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("run() end to end over the fixtures, with injected fetchers", () => {
+	const botCommits = commits.filter((c) => c.sha.startsWith("b0d472"));
+	const checksByPr: Record<number, Check[]> = { 33: flakyChecks };
+
+	const fetchers = {
+		openPrs: async () => prList,
+		prChecks: async (_repo: string, number: number) => checksByPr[number] ?? [],
+		prCommits: async (_repo: string, number: number) => (number === 33 || number === 34 ? botCommits : signedSubset),
+		prComments: async () => [] as string[],
+		mainChecks: async () => mainChecks,
+		openIssues: async () => issueList,
+		requiredContexts: async () => [...REQUIRED_CONTEXTS],
+	};
+
+	it("classifies every PR, plans the labels, and reports drift-free", async () => {
+		const recorded: Action[] = [];
+		const { summary } = await run({ repo: "EZiLHQ/ezil-os", since: null, post: false }, fetchers, async (a) => {
+			recorded.push(...a);
+		});
+
+		const p33 = summary.prs.find((p) => p.number === 33)!;
+		expect(p33.findings).toEqual(["ci-flaky", "ready-for-review"]);
+		expect(p33.labelsToAdd).toEqual(["size/S"]);
+		expect(p33.wouldPost).not.toBeNull(); // ci-flaky has a template
+
+		const p101 = summary.prs.find((p) => p.number === 101)!;
+		expect(p101.findings).toEqual(["template-incomplete", "size-xl", "draft"]);
+
+		const p102 = summary.prs.find((p) => p.number === 102)!;
+		expect(p102.findings).toEqual(["ready-for-review"]);
+		expect(p102.labelsToRemove).toEqual(["size/L"]);
+		expect(p102.wouldPost).toBeNull(); // ready-for-review is a signal, not a comment
+
+		expect(summary.requiredContextsDrift).toBeNull();
+		expect(summary.issues.find((i) => i.number === 201)!.labelsToAdd).toEqual(["needs-triage"]);
+		expect(summary.counts.openPrs).toBe(5);
+		expect(summary.counts.openIssues).toBe(4);
+	});
+
+	it("since filters by updatedAt", async () => {
+		const { summary } = await run({ repo: "r", since: "2026-09-05T10:30:00Z", post: false }, fetchers, async () => {});
+		// only #103 (11:00) is at/after 10:30 among PRs
+		expect(summary.prs.map((p) => p.number)).toEqual([103]);
+	});
+
+	it("reports drift when the constant and the live ruleset disagree", async () => {
+		const drifted = { ...fetchers, requiredContexts: async () => ["DCO", "a-new-required-check"] };
+		const { summary } = await run({ repo: "r", since: null, post: false }, drifted, async () => {});
+		expect(summary.requiredContextsDrift).not.toBeNull();
+		expect(summary.requiredContextsDrift!.join("\n")).toContain("a-new-required-check");
+	});
+});

--- a/tools/triage.ts
+++ b/tools/triage.ts
@@ -231,7 +231,7 @@ A check failed here that is currently green on \`main\` for the same name, and i
 
 	"not-required-red": `### A non-required check is red
 
-\`container (real image)\` and \`local (typecheck + unit + smoke)\` pull the desktop image from a private GitHub Container Registry package. A pull request from a fork — and a developer on an unprivileged machine — cannot read that package, so those checks come up red or skipped on outside contributions no matter what you changed (see [\`.github/workflows/ci.yml\` lines 62–72](${REPO_BLOB}/.github/workflows/ci.yml#L62-L72)). The \`Vercel\` preview deploy is a third-party check on the same footing. Neither is one of the fifteen required contexts, so this does not block your merge.`,
+A check failed here that is not among the fifteen required contexts. Two checks commonly do this on outside contributions: \`container (real image)\` and \`local (typecheck + unit + smoke)\` pull the desktop image from a private GitHub Container Registry package that a pull request from a fork — or a developer on an unprivileged machine — cannot read, so they come up red or skipped (see [\`.github/workflows/ci.yml\` lines 62–72](${REPO_BLOB}/.github/workflows/ci.yml#L62-L72)). The \`Vercel\` preview deploy is a third-party check on the same footing. Neither is one of the fifteen required contexts, so this does not block your merge.`,
 
 	"size-xl": `### This pull request is large (size/XL)
 

--- a/tools/triage.ts
+++ b/tools/triage.ts
@@ -1,0 +1,1007 @@
+/**
+ * A deterministic triage pass over the repository's open pull requests and
+ * issues.
+ *
+ * ## Why this exists, and what it deliberately is not
+ *
+ * The intake routine (plan Part B §B5) is a supervisor loop: a model reads what
+ * changed, drafts review text, and a maintainer merges. A model reading a wall
+ * of `gh` output and deciding what to say is neither cheap nor reproducible --
+ * two runs over the same repository disagree. So the *decisions* live here, as
+ * pure functions over typed inputs, and the model is left only the prose it is
+ * actually good at. `classifyPr` given the same PR, checks, commits and
+ * main-branch checks returns the same findings every time, and the tests below
+ * pin every one of them.
+ *
+ * The blast radius is bounded by construction. This tool **never closes, never
+ * merges, never re-runs a workflow, and never edits a body or title.** The only
+ * writes it can perform are adding a comment and adjusting labels, and even
+ * those happen only under `--post`; the default is a dry run that prints what it
+ * would do. `applyActions` accepts a closed union of three action kinds
+ * (`comment`, `add-label`, `remove-label`) so that "it cannot close a PR" is a
+ * property of the type, not a promise in a comment -- see `argsFor`, whose
+ * switch has nowhere to put a destructive verb, and the test that walks every
+ * action every fixture produces and asserts none escapes that set.
+ *
+ * ## Machine state lives outside the repository
+ *
+ * "What did I last look at" is a cursor, and a cursor is machine state, not
+ * source. It is written to `${XDG_CACHE_HOME:-~/.cache}/ezil-os/triage-cursor.json`,
+ * never inside the checkout, so a scheduled run on a loop leaves the working
+ * tree untouched and `git status` stays clean. A dry run writes nothing at all,
+ * cursor included; only `--post` advances it.
+ *
+ * ## The two contracts this file mirrors, and how they drift
+ *
+ * `REQUIRED_CONTEXTS` is the fifteen status checks that branch-protection
+ * ruleset 22265548 requires on `main` (measured 2026-09-05, not assumed). It is
+ * a constant here because `classifyPr` must be pure and the tests must be
+ * deterministic, but a constant that mirrors a live ruleset drifts silently --
+ * exactly the failure mode this project keeps paying for. So the CLI cross-checks
+ * the constant against the live ruleset at run time and prints a loud warning to
+ * stderr, and surfaces the drift in the JSON, rather than trusting the constant
+ * blindly. `container (real image)`, `local (typecheck + unit + smoke)` and
+ * `Vercel` are deliberately NOT in the set: a fork PR cannot pull the private
+ * desktop image, so those go red on every outside contribution -- see
+ * `.github/workflows/ci.yml` lines 62-72. A red check outside the required set
+ * is `not-required-red`, and that classification takes precedence over
+ * `ci-flaky` (a non-required check that happens to be green on `main` is still
+ * the fork limitation, not a flake).
+ *
+ * The DCO rule is a faithful re-implementation of `.github/workflows/dco.yml`:
+ * merge commits are skipped; the three bot authors it names are skipped by the
+ * SAME commit-author ident test (email suffix `@users.noreply.github.com` AND a
+ * name in the list), FIRST, before any trailer is read -- because the real
+ * Dependabot commit carries a `Signed-off-by` whose email does NOT match its
+ * author, and an "is a trailer missing?" gate would fail it; a trailer matches
+ * when its name equals the author name exactly and its email equals the author
+ * email case-insensitively. dco.yml is the authority; this is advisory, and the
+ * worst a divergence can do is post or withhold one advisory comment.
+ *
+ * ## Fixtures
+ *
+ * `tools/fixtures/triage/*.json` are captured from real `gh` output shapes; a
+ * `gh` upgrade can change those shapes and invalidate them. See the header of
+ * `triage.test.ts` for the provenance of each and how the flaky/red cases are
+ * anchored to a measured shell flake.
+ *
+ * No dependencies beyond Bun (`Bun.spawn`, `node:os`, `node:fs`), the house
+ * style shared with `waves.ts` and `ledger.ts`.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// The two mirrored contracts, as data.
+// ---------------------------------------------------------------------------
+
+/**
+ * The fifteen required status contexts on `main`, from ruleset 22265548
+ * (`gh api repos/EZiLHQ/ezil-os/rulesets/22265548`, measured 2026-09-05).
+ * `container (real image)`, `local (typecheck + unit + smoke)` and `Vercel` are
+ * intentionally absent -- see the file header.
+ */
+export const REQUIRED_CONTEXTS: readonly string[] = [
+	"worker (typecheck + unit) (ubuntu-latest)",
+	"worker (typecheck + unit) (windows-latest)",
+	"worker (typecheck + unit) (macos-latest)",
+	"app (typecheck + unit) (ubuntu-latest)",
+	"app (typecheck + unit) (windows-latest)",
+	"app (typecheck + unit) (macos-latest)",
+	"sdk + mcp (typecheck + unit) (ubuntu-latest)",
+	"sdk + mcp (typecheck + unit) (windows-latest)",
+	"sdk + mcp (typecheck + unit) (macos-latest)",
+	"shell (bundle check + browser suites) (ubuntu-latest)",
+	"shell (bundle check + browser suites) (windows-latest)",
+	"shell (bundle check + browser suites) (macos-latest)",
+	"tools (typecheck + unit)",
+	"DCO",
+	"CodeQL (javascript-typescript)",
+];
+
+const REQUIRED_SET: ReadonlySet<string> = new Set(REQUIRED_CONTEXTS);
+
+/**
+ * Bot commit authors that cannot sign the DCO, matched on the git author ident
+ * exactly as `dco.yml` does. Kept as data so the DCO test can assert the
+ * Dependabot email-mismatch trap directly.
+ */
+export const BOT_NAMES: readonly string[] = ["dependabot[bot]", "github-actions[bot]", "copilot-swe-agent[bot]"];
+export const BOT_EMAIL_SUFFIX = "@users.noreply.github.com";
+
+/** The ten path labels from `.github/labeler.yml`; an issue carrying none of these needs triage. */
+export const AREA_LABELS: readonly string[] = ["app", "worker", "sdk", "shell", "mcp", "e2e", "docs", "ci", "local", "tools"];
+
+/** The five size labels, in ascending order. */
+export const SIZE_LABELS: readonly string[] = ["size/XS", "size/S", "size/M", "size/L", "size/XL"];
+
+// ---------------------------------------------------------------------------
+// Types. `Check` is the normalised shape both `gh pr checks` and the commit
+// check-runs API are reduced to, so `classifyPr` never sees two shapes.
+// ---------------------------------------------------------------------------
+
+/** gh's rollup bucket for a single check. */
+export type Bucket = "pass" | "fail" | "pending" | "skipping" | "cancel";
+const BUCKETS: ReadonlySet<string> = new Set<Bucket>(["pass", "fail", "pending", "skipping", "cancel"]);
+
+export interface Check {
+	readonly name: string;
+	readonly bucket: Bucket;
+}
+
+export interface Author {
+	readonly login: string;
+	readonly is_bot: boolean;
+}
+
+export interface Label {
+	readonly name: string;
+}
+
+export interface PullRequest {
+	readonly number: number;
+	readonly title: string;
+	readonly author: Author;
+	readonly isDraft: boolean;
+	readonly labels: readonly Label[];
+	readonly additions: number;
+	readonly deletions: number;
+	readonly headRefName: string;
+	readonly body: string;
+	readonly updatedAt: string;
+}
+
+export interface Issue {
+	readonly number: number;
+	readonly title: string;
+	readonly labels: readonly Label[];
+	readonly body: string;
+	readonly updatedAt: string;
+}
+
+/** A commit reduced from the pulls/{n}/commits REST shape to what the DCO rule needs. */
+export interface Commit {
+	readonly sha: string;
+	readonly authorName: string;
+	readonly authorEmail: string;
+	readonly message: string;
+	/** Parent count; > 1 is a merge commit, which the DCO rule skips. */
+	readonly parents: number;
+}
+
+/**
+ * The closed set of findings `classifyPr` may return, in the canonical order
+ * they are reported and merged into a comment.
+ */
+export const FINDING_ORDER = [
+	"missing-dco",
+	"template-incomplete",
+	"ci-red",
+	"ci-flaky",
+	"not-required-red",
+	"size-xl",
+	"draft",
+	"ready-for-review",
+] as const;
+
+export type Finding = (typeof FINDING_ORDER)[number];
+
+// ---------------------------------------------------------------------------
+// Comment templates. Only the findings a contributor can act on get a body;
+// `draft` and `ready-for-review` are status signals the supervisor reads from
+// the JSON (§B5 routes `ready-for-review` to a review, not a canned comment),
+// and templating them would put a comment on every PR since one of the two
+// always fires. The absence of those two keys is asserted by the tests so the
+// interpretation is pinned, not merely omitted.
+// ---------------------------------------------------------------------------
+
+const REPO_BLOB = "https://github.com/EZiLHQ/ezil-os/blob/main";
+
+/**
+ * The findings that carry a contributor-facing comment. `CommentFinding` is the
+ * key type of `TEMPLATES`; the two status findings are excluded by omission.
+ */
+export type CommentFinding = "missing-dco" | "template-incomplete" | "ci-red" | "ci-flaky" | "not-required-red" | "size-xl";
+
+export const TEMPLATES: Readonly<Record<CommentFinding, string>> = {
+	"missing-dco": `### Missing or mismatched sign-off (DCO)
+
+One or more commits on this PR are missing a \`Signed-off-by\` trailer, or carry one whose name and email do not match the commit author. Every commit must certify the [Developer Certificate of Origin](https://developercertificate.org/) — see [CONTRIBUTING.md § Sign-off (DCO)](${REPO_BLOB}/CONTRIBUTING.md#sign-off-dco).
+
+To fix:
+
+- one commit: \`git commit --amend -s && git push --force-with-lease\`
+- several commits: \`git rebase --signoff <base> && git push --force-with-lease\`
+
+\`<base>\` is the commit your branch started from (usually \`origin/main\`). If the trailer is present but mismatched, set \`user.name\` and \`user.email\` to the identity you sign with, then amend or rebase as above.`,
+
+	"template-incomplete": `### The pull request description looks incomplete
+
+This PR's description contains none of the checklist items from the [pull request template](${REPO_BLOB}/.github/PULL_REQUEST_TEMPLATE.md). Please edit the description to keep the template's checklist — what changed, the size, the linked issue, and the sign-off / testing boxes — so a reviewer can see what was done and how it was tested. See [CONTRIBUTING.md § How to send a PR](${REPO_BLOB}/CONTRIBUTING.md#how-to-send-a-pr).`,
+
+	"ci-red": `### CI is red
+
+A required check failed here, and the same check is green on \`main\` for the same name — so this is a failure the change introduced, not a known flake. Open the failing check, read the failing step, and push a fix. See [CONTRIBUTING.md § Reading CI](${REPO_BLOB}/CONTRIBUTING.md#reading-ci). If you believe the failure is unrelated to your change, say so here and a maintainer will take a look.`,
+
+	"ci-flaky": `### A known-flaky check failed
+
+A check failed here that is currently green on \`main\` for the same name, and it is one this project has watched flake before — this is not your change. A maintainer will re-run it; there is nothing you need to do. If it fails again after a re-run it is tracked in the flake backlog. See [CONTRIBUTING.md § Reading CI](${REPO_BLOB}/CONTRIBUTING.md#reading-ci).`,
+
+	"not-required-red": `### A non-required check is red
+
+\`container (real image)\` and \`local (typecheck + unit + smoke)\` pull the desktop image from a private GitHub Container Registry package. A pull request from a fork — and a developer on an unprivileged machine — cannot read that package, so those checks come up red or skipped on outside contributions no matter what you changed (see [\`.github/workflows/ci.yml\` lines 62–72](${REPO_BLOB}/.github/workflows/ci.yml#L62-L72)). The \`Vercel\` preview deploy is a third-party check on the same footing. Neither is one of the fifteen required contexts, so this does not block your merge.`,
+
+	"size-xl": `### This pull request is large (size/XL)
+
+This change is over 1000 lines added + deleted, which is hard to review well. Where you can, split it into a stack of smaller PRs along natural seams — one concern per PR. See [CONTRIBUTING.md § PR size](${REPO_BLOB}/CONTRIBUTING.md#pr-size). If it genuinely cannot be split, say why here so a reviewer knows what they are looking at.`,
+};
+
+const COMMENT_FOOTER = `<sub>Automated triage from \`tools/triage.ts\` (dry-run by default; a maintainer runs \`--post\`). Reply here if something looks wrong.</sub>`;
+
+/** The idempotence marker a posted section carries, so a re-run skips a finding already commented. */
+export function marker(finding: Finding): string {
+	return `<!-- ezil-triage: ${finding} -->`;
+}
+
+function isCommentFinding(finding: Finding): finding is CommentFinding {
+	return finding in TEMPLATES;
+}
+
+// ---------------------------------------------------------------------------
+// Pure classification.
+// ---------------------------------------------------------------------------
+
+/** XS <= 20, S <= 100, M <= 400, L <= 1000, XL > 1000, over additions + deletions. */
+export function sizeBucket(changedLines: number): "XS" | "S" | "M" | "L" | "XL" {
+	if (changedLines <= 20) return "XS";
+	if (changedLines <= 100) return "S";
+	if (changedLines <= 400) return "M";
+	if (changedLines <= 1000) return "L";
+	return "XL";
+}
+
+export function sizeLabel(changedLines: number): string {
+	return `size/${sizeBucket(changedLines)}`;
+}
+
+/**
+ * A markdown task-list checkbox anywhere in the body. The template's completeness
+ * signal is coarse on purpose: a body that kept the template (even with every box
+ * unchecked) has checkboxes and is fine; a body that replaced the template with
+ * prose, or is empty, has none. This is decoupled from the exact checkbox text,
+ * which row I1 owns and may reword.
+ */
+export function hasChecklist(body: string): boolean {
+	return /^[ \t]*[-*][ \t]*\[[ xX]\]/m.test(body);
+}
+
+/** A bot author cannot fill the human template, so `template-incomplete` is suppressed for them. */
+export function isBotAuthor(pr: Pick<PullRequest, "author">): boolean {
+	return pr.author.is_bot === true || pr.author.login.endsWith("[bot]");
+}
+
+function isBotCommit(commit: Commit): boolean {
+	return commit.authorEmail.endsWith(BOT_EMAIL_SUFFIX) && BOT_NAMES.includes(commit.authorName);
+}
+
+/** Every `Signed-off-by:` trailer value in a commit message, key matched case-insensitively as git does. */
+export function signoffValues(message: string): string[] {
+	const values: string[] = [];
+	for (const line of message.split(/\r?\n/)) {
+		const m = /^[ \t]*signed-off-by[ \t]*:[ \t]*(.*?)[ \t]*$/i.exec(line);
+		if (m && m[1] !== undefined && m[1] !== "") values.push(m[1]);
+	}
+	return values;
+}
+
+/** Split a trailer value `Name <email>` the way `dco.yml`'s SOB_RE does; null if it does not parse. */
+export function parseSignoff(value: string): { name: string; email: string } | null {
+	const m = /^(.*\S)\s*<(.*)>\s*$/.exec(value);
+	if (!m || m[1] === undefined || m[2] === undefined) return null;
+	return { name: m[1], email: m[2] };
+}
+
+export interface UnsignedCommit {
+	readonly sha: string;
+	readonly reason: "no-trailer" | "mismatch";
+}
+
+/**
+ * The commits that would fail DCO, by the same rule `dco.yml` applies. Merge and
+ * bot commits are skipped (never reported). A commit passes if any of its
+ * `Signed-off-by` trailers has a name equal to the author name (exact) and an
+ * email equal to the author email (case-insensitive).
+ */
+export function unsignedCommits(commits: readonly Commit[]): UnsignedCommit[] {
+	const failures: UnsignedCommit[] = [];
+	for (const commit of commits) {
+		if (commit.parents > 1) continue; // merge: not the contributor's to sign
+		if (isBotCommit(commit)) continue; // bot: skipped FIRST, before any trailer is read
+		const values = signoffValues(commit.message);
+		if (values.length === 0) {
+			failures.push({ sha: commit.sha, reason: "no-trailer" });
+			continue;
+		}
+		const matched = values.some((value) => {
+			const parsed = parseSignoff(value);
+			return (
+				parsed !== null &&
+				parsed.name === commit.authorName &&
+				parsed.email.toLowerCase() === commit.authorEmail.toLowerCase()
+			);
+		});
+		if (!matched) failures.push({ sha: commit.sha, reason: "mismatch" });
+	}
+	return failures;
+}
+
+function isGreenOnMain(name: string, mainChecks: readonly Check[]): boolean {
+	let sawPass = false;
+	for (const check of mainChecks) {
+		if (check.name !== name) continue;
+		if (check.bucket === "fail") return false; // a red run on main means it is not reliably green
+		if (check.bucket === "pass") sawPass = true;
+	}
+	return sawPass;
+}
+
+/**
+ * The check-derived findings for a PR. For each failing check:
+ *   - not in the required set          -> `not-required-red` (fork/GHCR/Vercel; does not block)
+ *   - required and green on `main`     -> `ci-flaky`         (the #24 shell case)
+ *   - required and not green on `main` -> `ci-red`           (a real regression)
+ * `not-required-red` is decided FIRST: a non-required check that is green on main
+ * is still the fork limitation, not a flake.
+ */
+export function classifyChecks(checks: readonly Check[], mainChecks: readonly Check[]): Set<Finding> {
+	const findings = new Set<Finding>();
+	for (const check of checks) {
+		if (check.bucket !== "fail") continue;
+		if (!REQUIRED_SET.has(check.name)) {
+			findings.add("not-required-red");
+		} else if (isGreenOnMain(check.name, mainChecks)) {
+			findings.add("ci-flaky");
+		} else {
+			findings.add("ci-red");
+		}
+	}
+	return findings;
+}
+
+/**
+ * The ordered findings for one pull request. Pure: the same inputs give the same
+ * output, which is what lets the supervisor act on the JSON without re-deciding.
+ */
+export function classifyPr(
+	pr: PullRequest,
+	checks: readonly Check[],
+	commits: readonly Commit[],
+	mainChecks: readonly Check[],
+): Finding[] {
+	const found = new Set<Finding>();
+
+	if (unsignedCommits(commits).length > 0) found.add("missing-dco");
+	if (!isBotAuthor(pr) && !hasChecklist(pr.body)) found.add("template-incomplete");
+	for (const finding of classifyChecks(checks, mainChecks)) found.add(finding);
+	if (sizeBucket(pr.additions + pr.deletions) === "XL") found.add("size-xl");
+	found.add(pr.isDraft ? "draft" : "ready-for-review");
+
+	return FINDING_ORDER.filter((finding) => found.has(finding));
+}
+
+export interface LabelChange {
+	readonly add: readonly string[];
+	readonly remove: readonly string[];
+}
+
+/** The size label a PR should carry, and the other four to strip if present. Never touches non-size labels. */
+export function prLabelChange(pr: Pick<PullRequest, "additions" | "deletions" | "labels">): LabelChange {
+	const want = sizeLabel(pr.additions + pr.deletions);
+	const current = new Set(pr.labels.map((label) => label.name));
+	return {
+		add: current.has(want) ? [] : [want],
+		remove: SIZE_LABELS.filter((size) => size !== want && current.has(size)),
+	};
+}
+
+/** `needs-triage` iff the issue carries no area label and does not already have it. Never removes labels. */
+export function issueLabelChange(issue: Pick<Issue, "labels">): LabelChange {
+	const current = new Set(issue.labels.map((label) => label.name));
+	const hasArea = AREA_LABELS.some((area) => current.has(area));
+	const needsTriage = !hasArea && !current.has("needs-triage");
+	return { add: needsTriage ? ["needs-triage"] : [], remove: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Comment assembly and idempotence.
+// ---------------------------------------------------------------------------
+
+/** Every triage marker present across a PR's existing comment bodies. */
+export function markersIn(commentBodies: readonly string[]): Set<Finding> {
+	const present = new Set<Finding>();
+	const re = /<!--\s*ezil-triage:\s*([a-z-]+)\s*-->/g;
+	for (const body of commentBodies) {
+		let m: RegExpExecArray | null;
+		re.lastIndex = 0;
+		while ((m = re.exec(body)) !== null) {
+			const name = m[1];
+			if (name !== undefined && (FINDING_ORDER as readonly string[]).includes(name)) {
+				present.add(name as Finding);
+			}
+		}
+	}
+	return present;
+}
+
+/** The comment findings that should still be posted: those with a body, whose marker is not already present. */
+export function findingsToPost(findings: readonly Finding[], alreadyPosted: ReadonlySet<Finding>): CommentFinding[] {
+	return findings.filter((finding): finding is CommentFinding => isCommentFinding(finding) && !alreadyPosted.has(finding));
+}
+
+/** One comment merging every finding's section, each behind its marker. Null when there is nothing to say. */
+export function buildComment(findings: readonly Finding[]): string | null {
+	const sections = FINDING_ORDER.filter(
+		(finding): finding is CommentFinding => findings.includes(finding) && isCommentFinding(finding),
+	).map((finding) => `${marker(finding)}\n${TEMPLATES[finding]}`);
+	if (sections.length === 0) return null;
+	return `${sections.join("\n\n")}\n\n${COMMENT_FOOTER}`;
+}
+
+// ---------------------------------------------------------------------------
+// The action plan: a closed union, so destruction is unrepresentable.
+// ---------------------------------------------------------------------------
+
+export type ActionKind = "comment" | "add-label" | "remove-label";
+
+export interface Action {
+	readonly kind: ActionKind;
+	readonly target: "pr" | "issue";
+	readonly number: number;
+	/** For `comment`. */
+	readonly body?: string;
+	/** For `add-label` / `remove-label`. */
+	readonly label?: string;
+}
+
+export interface PrTriage {
+	readonly number: number;
+	readonly title: string;
+	readonly findings: readonly Finding[];
+	readonly size: string;
+	readonly labelsToAdd: readonly string[];
+	readonly labelsToRemove: readonly string[];
+	/** Names of checks in bucket `fail`, so the supervisor can see WHICH contexts are red. */
+	readonly redChecks: readonly string[];
+	/** The comment that would be posted this run (markers already present are excluded), or null. */
+	readonly wouldPost: string | null;
+}
+
+export interface IssueTriage {
+	readonly number: number;
+	readonly title: string;
+	readonly findings: readonly string[];
+	readonly labelsToAdd: readonly string[];
+	readonly labelsToRemove: readonly string[];
+	readonly wouldPost: string | null;
+}
+
+/** Turn triage results into the flat, closed-union action list `applyActions` executes. */
+export function planActions(prs: readonly PrTriage[], issues: readonly IssueTriage[]): Action[] {
+	const actions: Action[] = [];
+	for (const pr of prs) {
+		if (pr.wouldPost !== null) actions.push({ kind: "comment", target: "pr", number: pr.number, body: pr.wouldPost });
+		for (const label of pr.labelsToAdd) actions.push({ kind: "add-label", target: "pr", number: pr.number, label });
+		for (const label of pr.labelsToRemove) actions.push({ kind: "remove-label", target: "pr", number: pr.number, label });
+	}
+	for (const issue of issues) {
+		if (issue.wouldPost !== null)
+			actions.push({ kind: "comment", target: "issue", number: issue.number, body: issue.wouldPost });
+		for (const label of issue.labelsToAdd) actions.push({ kind: "add-label", target: "issue", number: issue.number, label });
+		for (const label of issue.labelsToRemove)
+			actions.push({ kind: "remove-label", target: "issue", number: issue.number, label });
+	}
+	return actions;
+}
+
+/**
+ * The exact `gh` argument vector for one action. The switch is total over
+ * `ActionKind`, and there is deliberately no branch that could `close`, `merge`,
+ * `ready`, `review` or `rerun` -- the subcommands are only `comment` and `edit`.
+ * Pure and exported so a test can assert that property over every action.
+ */
+export function argsFor(action: Action, repo: string): string[] {
+	const noun = action.target; // "pr" | "issue"
+	switch (action.kind) {
+		case "comment":
+			return [noun, "comment", String(action.number), "-R", repo, "--body", action.body ?? ""];
+		case "add-label":
+			return [noun, "edit", String(action.number), "-R", repo, "--add-label", action.label ?? ""];
+		case "remove-label":
+			return [noun, "edit", String(action.number), "-R", repo, "--remove-label", action.label ?? ""];
+	}
+}
+
+/**
+ * Execute the plan -- but only when `post` is true. In a dry run this is a
+ * no-op, which is the whole safety property: the default cannot write. `run` is
+ * injected so a test proves the gate (zero calls dry, N calls posting) without a
+ * real `gh` ever being reachable.
+ */
+export async function applyActions(
+	actions: readonly Action[],
+	opts: { post: boolean; repo: string; run: (args: string[]) => Promise<void> },
+): Promise<void> {
+	if (!opts.post) return;
+	for (const action of actions) {
+		await opts.run(argsFor(action, opts.repo));
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Normalisers from raw `gh` shapes to the typed inputs above.
+// ---------------------------------------------------------------------------
+
+function asBucket(value: unknown): Bucket {
+	if (typeof value === "string" && BUCKETS.has(value)) return value as Bucket;
+	throw new Error(`unrecognised check bucket ${JSON.stringify(value)}; a gh upgrade may have changed the vocabulary.`);
+}
+
+/** From `gh pr checks --json name,bucket,state`. */
+export function normalizePrChecks(raw: unknown): Check[] {
+	if (!Array.isArray(raw)) throw new Error("pr checks: expected a JSON array.");
+	return raw.map((entry) => {
+		const row = entry as { name?: unknown; bucket?: unknown };
+		if (typeof row.name !== "string") throw new Error("pr checks: a row has no string name.");
+		return { name: row.name, bucket: asBucket(row.bucket) };
+	});
+}
+
+/** conclusion+status from the REST check-runs API, reduced to a bucket. */
+function conclusionToBucket(conclusion: unknown, status: unknown): Bucket {
+	if (status !== "completed") return "pending";
+	switch (conclusion) {
+		case "success":
+			return "pass";
+		case "failure":
+		case "timed_out":
+		case "action_required":
+		case "startup_failure":
+			return "fail";
+		case "cancelled":
+			return "cancel";
+		case "skipped":
+		case "neutral":
+			return "skipping";
+		default:
+			return "pending";
+	}
+}
+
+/** From `gh api repos/{repo}/commits/{ref}/check-runs`. */
+export function normalizeMainChecks(raw: unknown): Check[] {
+	const runs = (raw as { check_runs?: unknown }).check_runs;
+	if (!Array.isArray(runs)) throw new Error("main check-runs: expected an object with a check_runs array.");
+	return runs.map((entry) => {
+		const row = entry as { name?: unknown; conclusion?: unknown; status?: unknown };
+		if (typeof row.name !== "string") throw new Error("main check-runs: a run has no string name.");
+		return { name: row.name, bucket: conclusionToBucket(row.conclusion, row.status) };
+	});
+}
+
+/** From `gh api repos/{repo}/pulls/{n}/commits`. */
+export function normalizeCommits(raw: unknown): Commit[] {
+	if (!Array.isArray(raw)) throw new Error("pr commits: expected a JSON array.");
+	return raw.map((entry) => {
+		const row = entry as {
+			sha?: unknown;
+			commit?: { message?: unknown; author?: { name?: unknown; email?: unknown } };
+			parents?: unknown;
+		};
+		const author = row.commit?.author;
+		if (typeof row.sha !== "string") throw new Error("pr commits: a commit has no sha.");
+		if (typeof author?.name !== "string" || typeof author.email !== "string")
+			throw new Error(`pr commits: commit ${row.sha} has no author name/email.`);
+		return {
+			sha: row.sha,
+			authorName: author.name,
+			authorEmail: author.email,
+			message: typeof row.commit?.message === "string" ? row.commit.message : "",
+			parents: Array.isArray(row.parents) ? row.parents.length : 1,
+		};
+	});
+}
+
+// ---------------------------------------------------------------------------
+// The cursor: machine state, outside the repository.
+// ---------------------------------------------------------------------------
+
+export interface Cursor {
+	readonly since: string;
+	readonly updatedAt: string;
+}
+
+export function cursorPath(): string {
+	const base = process.env["XDG_CACHE_HOME"] ?? join(homedir(), ".cache");
+	return join(base, "ezil-os", "triage-cursor.json");
+}
+
+/**
+ * Read the cursor. A missing file is "first run" (null). A file that exists but
+ * does not parse is a hard error, never a silent fall-through to null: a
+ * corrupt cursor that quietly reprocessed everything would look identical to a
+ * healthy first run.
+ */
+export function readCursor(path: string): Cursor | null {
+	let text: string;
+	try {
+		text = readFileSync(path, "utf8");
+	} catch {
+		return null;
+	}
+	let raw: unknown;
+	try {
+		raw = JSON.parse(text);
+	} catch (cause) {
+		throw new Error(`cursor at ${path} is present but not JSON (${String(cause)}); refusing to treat it as a first run.`);
+	}
+	const row = raw as { since?: unknown; updatedAt?: unknown };
+	if (typeof row.since !== "string" || typeof row.updatedAt !== "string")
+		throw new Error(`cursor at ${path} is malformed; expected {since, updatedAt} strings.`);
+	return { since: row.since, updatedAt: row.updatedAt };
+}
+
+function writeCursor(path: string, cursor: Cursor): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(cursor, null, 2)}\n`);
+}
+
+/** A row updated at or after `since` is in scope. A null `since` (first run) is in scope for everything. */
+export function inScope(updatedAt: string, since: string | null): boolean {
+	return since === null || updatedAt >= since;
+}
+
+// ---------------------------------------------------------------------------
+// gh I/O. Every call is a typed failure on trouble, never a silent empty list.
+// ---------------------------------------------------------------------------
+
+export class GhError extends Error {}
+
+async function sh(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	const proc = Bun.spawn(["gh", ...args], { stdout: "pipe", stderr: "pipe" });
+	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	const exitCode = await proc.exited;
+	return { stdout, stderr, exitCode };
+}
+
+/** A `gh` call whose stdout is JSON; a non-zero exit is a GhError, never an empty result. */
+async function ghJson<T>(args: string[]): Promise<T> {
+	const { stdout, stderr, exitCode } = await sh(args);
+	if (exitCode !== 0) throw new GhError(`gh ${args.join(" ")} exited ${exitCode}: ${stderr.trim()}`);
+	try {
+		return JSON.parse(stdout) as T;
+	} catch (cause) {
+		throw new GhError(`gh ${args.join(" ")} did not return JSON: ${String(cause)}`);
+	}
+}
+
+/**
+ * `gh pr checks --json` is the one call keyed on parseable stdout rather than
+ * exit code: measured 2026-09-05 it exits 0 with `--json` even when a check is
+ * failing or pending, but the TTY form exits non-zero for both, and a gh upgrade
+ * could bring that behaviour to `--json`. So: JSON on stdout is success (even an
+ * empty array); a genuinely check-less PR reports "no checks" on stderr and is an
+ * empty list, not an error; anything else is a GhError.
+ */
+async function ghChecks(repo: string, number: number): Promise<Check[]> {
+	const { stdout, stderr } = await sh(["pr", "checks", String(number), "-R", repo, "--json", "name,bucket,state"]);
+	const trimmed = stdout.trim();
+	if (trimmed !== "") {
+		try {
+			return normalizePrChecks(JSON.parse(trimmed));
+		} catch (cause) {
+			throw new GhError(`pr checks ${number}: unparseable output: ${String(cause)}`);
+		}
+	}
+	if (/no check/i.test(stderr)) return []; // a PR with no checks: empty is the truth
+	throw new GhError(`pr checks ${number} produced no JSON: ${stderr.trim()}`);
+}
+
+interface Fetchers {
+	openPrs(repo: string): Promise<PullRequest[]>;
+	prChecks(repo: string, number: number): Promise<Check[]>;
+	prCommits(repo: string, number: number): Promise<Commit[]>;
+	prComments(repo: string, number: number): Promise<string[]>;
+	mainChecks(repo: string): Promise<Check[]>;
+	openIssues(repo: string): Promise<Issue[]>;
+	requiredContexts(repo: string): Promise<string[] | null>;
+}
+
+const liveFetchers: Fetchers = {
+	openPrs: (repo) =>
+		ghJson<PullRequest[]>([
+			"pr",
+			"list",
+			"-R",
+			repo,
+			"--state",
+			"open",
+			"--limit",
+			"100",
+			"--json",
+			"number,title,author,isDraft,labels,additions,deletions,headRefName,body,updatedAt",
+		]),
+	prChecks: (repo, number) => ghChecks(repo, number),
+	prCommits: async (repo, number) =>
+		normalizeCommits(await ghJson<unknown>(["api", `repos/${repo}/pulls/${number}/commits?per_page=100`])),
+	prComments: async (repo, number) => {
+		const view = await ghJson<{ comments?: { body?: unknown }[] }>([
+			"pr",
+			"view",
+			String(number),
+			"-R",
+			repo,
+			"--json",
+			"comments",
+		]);
+		return (view.comments ?? []).map((c) => (typeof c.body === "string" ? c.body : ""));
+	},
+	mainChecks: async (repo) =>
+		normalizeMainChecks(await ghJson<unknown>(["api", `repos/${repo}/commits/main/check-runs?per_page=100`])),
+	openIssues: (repo) =>
+		ghJson<Issue[]>([
+			"issue",
+			"list",
+			"-R",
+			repo,
+			"--state",
+			"open",
+			"--limit",
+			"100",
+			"--json",
+			"number,title,labels,body,updatedAt",
+		]),
+	requiredContexts: async (repo) => {
+		try {
+			const rulesets = await ghJson<{ id: number }[]>(["api", `repos/${repo}/rulesets`]);
+			for (const rs of rulesets) {
+				const detail = await ghJson<{
+					rules?: { type?: string; parameters?: { required_status_checks?: { context?: string }[] } }[];
+				}>(["api", `repos/${repo}/rulesets/${rs.id}`]);
+				const rule = (detail.rules ?? []).find((r) => r.type === "required_status_checks");
+				const contexts = rule?.parameters?.required_status_checks;
+				if (contexts) return contexts.map((c) => c.context ?? "").filter((c) => c !== "");
+			}
+			return null;
+		} catch {
+			return null; // the cross-check is advisory; a token without ruleset scope must not break triage
+		}
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Orchestration and the JSON summary.
+// ---------------------------------------------------------------------------
+
+export interface Summary {
+	readonly repo: string;
+	readonly since: string | null;
+	readonly cursor: { readonly path: string; readonly since: string | null; readonly advanced: boolean };
+	readonly prs: readonly PrTriage[];
+	readonly issues: readonly IssueTriage[];
+	readonly requiredContextsDrift: readonly string[] | null;
+	readonly counts: {
+		readonly openPrs: number;
+		readonly openIssues: number;
+		readonly prsWithFindings: number;
+		readonly findings: Readonly<Record<string, number>>;
+		readonly wouldComment: number;
+		readonly wouldAddLabels: number;
+		readonly wouldRemoveLabels: number;
+	};
+}
+
+export interface RunOptions {
+	readonly repo: string;
+	readonly since: string | null;
+	readonly post: boolean;
+}
+
+/**
+ * Gather, classify, plan, and (only under `post`) apply. Returns the summary and
+ * the human-readable lines; the caller decides where each goes. Kept as one
+ * function taking injected fetchers so the pure core stays testable and the CLI
+ * shell below is thin.
+ */
+export async function run(
+	options: RunOptions,
+	fetchers: Fetchers,
+	apply: (actions: readonly Action[]) => Promise<void>,
+): Promise<{ summary: Summary; lines: string[] }> {
+	const { repo, since, post } = options;
+	const lines: string[] = [];
+
+	const [allPrs, allIssues, mainChecks, liveRequired] = await Promise.all([
+		fetchers.openPrs(repo),
+		fetchers.openIssues(repo),
+		fetchers.mainChecks(repo),
+		fetchers.requiredContexts(repo),
+	]);
+
+	const prs = allPrs.filter((pr) => inScope(pr.updatedAt, since));
+	const issues = allIssues.filter((issue) => inScope(issue.updatedAt, since));
+
+	const prTriages: PrTriage[] = [];
+	for (const pr of prs) {
+		const [checks, commits, comments] = await Promise.all([
+			fetchers.prChecks(repo, pr.number),
+			fetchers.prCommits(repo, pr.number),
+			fetchers.prComments(repo, pr.number),
+		]);
+		const findings = classifyPr(pr, checks, commits, mainChecks);
+		const labels = prLabelChange(pr);
+		const toPost = findingsToPost(findings, markersIn(comments));
+		prTriages.push({
+			number: pr.number,
+			title: pr.title,
+			findings,
+			size: sizeLabel(pr.additions + pr.deletions),
+			labelsToAdd: labels.add,
+			labelsToRemove: labels.remove,
+			redChecks: checks.filter((c) => c.bucket === "fail").map((c) => c.name),
+			wouldPost: buildComment(toPost),
+		});
+	}
+
+	const issueTriages: IssueTriage[] = issues.map((issue) => {
+		const labels = issueLabelChange(issue);
+		return {
+			number: issue.number,
+			title: issue.title,
+			findings: labels.add.includes("needs-triage") ? ["needs-triage"] : [],
+			labelsToAdd: labels.add,
+			labelsToRemove: labels.remove,
+			wouldPost: null,
+		};
+	});
+
+	const actions = planActions(prTriages, issueTriages);
+	await apply(actions);
+
+	// Cross-check the mirrored constant against the live ruleset.
+	let drift: string[] | null = null;
+	if (liveRequired !== null) {
+		const live = new Set(liveRequired);
+		const constant = new Set(REQUIRED_CONTEXTS);
+		const missing = liveRequired.filter((c) => !constant.has(c));
+		const extra = REQUIRED_CONTEXTS.filter((c) => !live.has(c));
+		if (missing.length > 0 || extra.length > 0) {
+			drift = [
+				...missing.map((c) => `+ live requires ${JSON.stringify(c)} (not in REQUIRED_CONTEXTS)`),
+				...extra.map((c) => `- REQUIRED_CONTEXTS has ${JSON.stringify(c)} (no longer required live)`),
+			];
+			lines.push(`WARNING: REQUIRED_CONTEXTS has drifted from ruleset on ${repo}:`);
+			for (const d of drift) lines.push(`  ${d}`);
+		}
+	}
+
+	const findingCounts: Record<string, number> = {};
+	for (const pr of prTriages) for (const f of pr.findings) findingCounts[f] = (findingCounts[f] ?? 0) + 1;
+
+	const commentCount = actions.filter((a) => a.kind === "comment").length;
+	const addCount = actions.filter((a) => a.kind === "add-label").length;
+	const removeCount = actions.filter((a) => a.kind === "remove-label").length;
+
+	const summary: Summary = {
+		repo,
+		since,
+		cursor: { path: cursorPath(), since, advanced: post },
+		prs: prTriages,
+		issues: issueTriages,
+		requiredContextsDrift: drift,
+		counts: {
+			openPrs: prs.length,
+			openIssues: issues.length,
+			prsWithFindings: prTriages.filter((pr) => pr.findings.some((f) => f !== "ready-for-review" && f !== "draft")).length,
+			findings: findingCounts,
+			wouldComment: commentCount,
+			wouldAddLabels: addCount,
+			wouldRemoveLabels: removeCount,
+		},
+	};
+
+	for (const pr of prTriages) {
+		const verb = post ? (pr.wouldPost ? "posted" : "no comment") : pr.wouldPost ? "would post" : "no comment";
+		lines.push(
+			`PR #${pr.number} [${pr.size}] ${pr.findings.join(", ") || "(none)"} — ${verb}` +
+				(pr.labelsToAdd.length || pr.labelsToRemove.length
+					? `; labels +[${pr.labelsToAdd.join(", ")}] -[${pr.labelsToRemove.join(", ")}]`
+					: ""),
+		);
+	}
+	for (const issue of issueTriages) {
+		lines.push(
+			`issue #${issue.number} ${issue.findings.join(", ") || "(no area label needed)"} — labels +[${issue.labelsToAdd.join(", ")}]`,
+		);
+	}
+	lines.push(
+		`${post ? "POSTED" : "dry run"}: ${prs.length} PR(s), ${issues.length} issue(s); ` +
+			`${commentCount} comment(s), ${addCount} label add(s), ${removeCount} label removal(s).`,
+	);
+
+	return { summary, lines };
+}
+
+// ---------------------------------------------------------------------------
+// CLI.
+// ---------------------------------------------------------------------------
+
+export interface CliArgs {
+	readonly repo: string;
+	readonly since: string | null;
+	readonly post: boolean;
+	readonly help: boolean;
+}
+
+export function parseArgs(argv: readonly string[]): CliArgs {
+	let repo = "EZiLHQ/ezil-os";
+	let since: string | null = null;
+	let post = false;
+	let help = false;
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		if (arg === "--repo") {
+			const value = argv[i + 1];
+			if (value === undefined) throw new Error("--repo needs an owner/name value.");
+			repo = value;
+			i += 1;
+		} else if (arg === "--since") {
+			const value = argv[i + 1];
+			if (value === undefined) throw new Error("--since needs an ISO timestamp.");
+			since = value;
+			i += 1;
+		} else if (arg === "--post") {
+			post = true;
+		} else if (arg === "--help" || arg === "-h") {
+			help = true;
+		} else {
+			throw new Error(`unknown argument ${JSON.stringify(arg)}. Flags: --repo <owner/name>, --since <iso>, --post.`);
+		}
+	}
+	return { repo, since, post, help };
+}
+
+if (import.meta.main) {
+	const args = parseArgs(process.argv.slice(2));
+	if (args.help) {
+		process.stderr.write(
+			"triage.ts — deterministic triage over open PRs and issues.\n" +
+				"  --repo <owner/name>   default EZiLHQ/ezil-os\n" +
+				"  --since <iso>         override the cursor; default reads the cursor, else all\n" +
+				"  --post                the ONLY flag that writes (labels + comments). Default is a dry run.\n" +
+				`  cursor: ${cursorPath()} (outside the repository)\n`,
+		);
+		process.exit(0);
+	}
+
+	const path = cursorPath();
+	const since = args.since ?? readCursor(path)?.since ?? null;
+
+	const { summary, lines } = await run({ repo: args.repo, since, post: args.post }, liveFetchers, (actions) =>
+		applyActions(actions, {
+			post: args.post,
+			repo: args.repo,
+			run: async (ghArgs) => {
+				const { stderr, exitCode } = await sh(ghArgs);
+				if (exitCode !== 0) throw new GhError(`gh ${ghArgs.join(" ")} exited ${exitCode}: ${stderr.trim()}`);
+			},
+		}),
+	);
+
+	// Only --post advances the cursor, and only after acting. A dry run leaves no trace.
+	if (args.post) writeCursor(path, { since: new Date().toISOString(), updatedAt: new Date().toISOString() });
+
+	for (const line of lines) process.stderr.write(`${line}\n`);
+	process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}


### PR DESCRIPTION
## What

`tools/triage.ts` — a deterministic triage pass over open pull requests and issues (round INTAKE, row I5). Reads with `gh`; classifies each PR/issue with pure, unit-tested functions; **dry-run by default, `--post` the only flag that writes** (labels + comments). It **never closes, merges, re-runs a workflow, or edits a body** — that is a property of the closed-union action plan (`comment` / `add-label` / `remove-label`), not a promise in a comment.

## Why it is shaped this way

The §B5 intake routine is a supervisor loop; the *decisions* belong in code so two runs agree, leaving a model only the prose it is good at. Findings: `missing-dco`, `template-incomplete`, `ci-red`, `ci-flaky`, `not-required-red`, `size-xl`, `draft`, `ready-for-review`.

- **Flaky discriminator**: a failing required check that is green on `main` for the same name is `ci-flaky` (the #24 shell case); red on both / absent is `ci-red`. `not-required-red` (a red check outside the fifteen required contexts — `container (real image)`, `local (…)`, `Vercel`) is decided **first**, because a non-required check that happens to be green on `main` is still the fork/GHCR limitation, not a flake.
- **DCO** mirrors `.github/workflows/dco.yml` exactly: merge commits skipped; the three bot authors skipped by commit-author ident **before** any trailer is read (the real Dependabot commit's trailer email does not match its author); a trailer matches on name (exact) + email (case-insensitive).
- **Idempotence**: every posted section carries `<!-- ezil-triage: <finding> -->`; a re-run skips a finding whose marker is already present.
- The cursor lives at `~/.cache/ezil-os/triage-cursor.json` — **outside the repo** (machine state, not source); a dry run writes nothing.
- `REQUIRED_CONTEXTS` mirrors ruleset 22265548; the CLI cross-checks it against the live ruleset and reports drift, so the constant cannot rot silently.

## Verification

- `./tools/test.sh tools` → **136 pass / 0 fail / 0 skip** across 3 files (typecheck clean); `triage.test.ts` alone = **60 pass / 0 fail**, 196 `expect()` calls.
- **Mutation-proof** of the flaky discriminator: making `isGreenOnMain` ignore `mainChecks` turns the two `ci-flaky` assertions into `ci-red` (2 fail); restored → 136 pass. A permanent regression form is in the suite (`classifyChecks(flaky, []) → ci-red`).
- **Live DRY run** against this repo (no `--post`), pasted below — 2 open PRs, `requiredContextsDrift: null` (the 15-context constant matches the live ruleset), no cursor written, `git status` clean.

```
PR #34 [size/M] not-required-red, ready-for-review — would post; labels +[size/M] -[]
PR #33 [size/S] not-required-red, ready-for-review — would post; labels +[size/S] -[]
dry run: 2 PR(s), 0 issue(s); 2 comment(s), 2 label add(s), 0 label removal(s).
```

`counts`: `{openPrs: 2, openIssues: 0, prsWithFindings: 2, findings: {not-required-red: 2, ready-for-review: 2}, wouldComment: 2, wouldAddLabels: 2, wouldRemoveLabels: 0}`

## Deviations (all deliberate, none worked around silently)

1. **Repo state moved since the brief.** The brief expected three open PRs incl. a flaky shell leg; #31/#32 merged and #24's flake is history. The two open PRs are Dependabot with only `Vercel` red. The flaky proof therefore lives in the fixtures (anchored to the measured #24/#31 shell pattern, provenance in the test header) and the mutation-proof — not the live run.
2. **`template-incomplete` is suppressed for bot authors** (the brief's rule is unconditional). Commenting "fill the template" on every dependency bump is the noise the marker design exists to prevent; both sides are unit-tested.
3. **Findings set** follows this row's brief (adds `not-required-red` + `draft`, drops the plan's `needs-prereq`).

## Shared contract / blind spots

- Templates link CONTRIBUTING anchors `#sign-off-dco` (live, pinned by `dco.yml`), and `#reading-ci` / `#pr-size` / `#how-to-send-a-pr` (created by **row I1**, matching the section names the plan mandates). A slug mismatch is a live-link bug the tests cannot catch — grep I1's headings.
- `doneRung` **target** is `INDEPENDENT_TEST_PASS`; the independent leg is this PR's required `tools (typecheck + unit)` context — reached when that goes green (auto-merge gates on it).
- `--post` was **never** run; the first real post is a supervisor decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
