### PR TITLE
test: container suites remove their container on SIGTERM/SIGINT; honest pixel buckets (row I0d)

### DIFF
--- a/artifacts/runs/wf-os-2026-09-04/I0d.json
+++ b/artifacts/runs/wf-os-2026-09-04/I0d.json
@@ -1,9 +1,10 @@
 {
   "taskId": "I0d",
   "runId": "wf-os-2026-09-04",
-  "status": "running",
+  "status": "done",
   "doneRung": "INDEPENDENT_TEST_PASS",
-  "evidence": "started: pixels.ts bucket fix (Math.floor over 0..31, 32 buckets) landed and mutation-proved (13 pass / 0 fail restored; mutant Math.round -> 12 pass / 1 fail, Expected 32 Received 33). Signal-trap work on the three worker container suites not yet started.",
+  "evidence": "pixels.ts: floor(l/8) over 0..31 = 32 buckets, mutation-proved (13 pass; mutant Math.round -> Expected 32 Received 33); signal traps in all three container suites; SIGTERM proof on neko-browser-window (supervisor-run): container up in 2 s, kill -TERM -> bun exited 143, docker ps -a shows no container; smoke 6/0 with buckets=28/32 (oracle thresholds unchanged); tools/test.sh worker 1075 pass / 1 known skip / 1 fail; the fail is mobile-keyboard '48px affordance' = this host's ezil-integrated:local built from wip/mobile-keyboard (M1): 8/1 there, 9/0 against ezil-m1-mainverify:local in this tree",
   "startedAt": "2026-09-04T23:38:19Z",
-  "updatedAt": "2026-09-04T23:38:19Z"
+  "updatedAt": "2026-09-05T00:16:15Z",
+  "landedBy": "supervisor (agent stood down after its verification loop stalled)"
 }

--- a/artifacts/runs/wf-os-2026-09-04/I0d.json
+++ b/artifacts/runs/wf-os-2026-09-04/I0d.json
@@ -1,0 +1,9 @@
+{
+  "taskId": "I0d",
+  "runId": "wf-os-2026-09-04",
+  "status": "running",
+  "doneRung": "INDEPENDENT_TEST_PASS",
+  "evidence": "started: pixels.ts bucket fix (Math.floor over 0..31, 32 buckets) landed and mutation-proved (13 pass / 0 fail restored; mutant Math.round -> 12 pass / 1 fail, Expected 32 Received 33). Signal-trap work on the three worker container suites not yet started.",
+  "startedAt": "2026-09-04T23:38:19Z",
+  "updatedAt": "2026-09-04T23:38:19Z"
+}

--- a/local/src/pixels.ts
+++ b/local/src/pixels.ts
@@ -80,7 +80,14 @@ export function luminanceStats(rgba: ArrayLike<number>): LuminanceStats {
         sum += l;
         sumSquares += l * l;
         samples++;
-        buckets.add(Math.round(l / 8));
+        // 🔴 `Math.floor`, not `Math.round`. Luminance ranges over `0…255`
+        // inclusive; `floor(l / 8)` maps that onto `0…31` -- exactly 32
+        // distinct buckets, matching the doc comment above and the `/32`
+        // suffix in `describeStats`. `Math.round` was measured to produce
+        // 33 (`0…32`, because `round(255 / 8) = 32`) -- an arithmetically
+        // impossible "33/32" in the printed diagnostic. See
+        // `docs/CONFIDENCE-MAP.md` section 3.5(a) and `local/tests/pixels.test.ts`.
+        buckets.add(Math.floor(l / 8));
     }
     const mean = sum / samples;
     // `max(0, …)` because the one-pass form can go a hair negative on a

--- a/local/tests/pixels.test.ts
+++ b/local/tests/pixels.test.ts
@@ -66,6 +66,16 @@ const DETAILED = frame(160, 100, (i) => {
     const v = (i * 2654435761) % 256;
     return [v, (v * 3) % 256, (v * 7) % 256];
 });
+/**
+ * THE FIXTURE THAT PINS THE BUCKET ARITHMETIC. Every grey level 0..255
+ * appears (16,000 pixels cycling i % 256), so this hits every possible
+ * floor(l / 8) bucket exactly once: 0..31, i.e. 32 distinct values.
+ * Math.round(l / 8) instead would additionally hit round(255 / 8) = 32,
+ * an arithmetically impossible 33rd bucket over a /32 label -- the defect
+ * docs/CONFIDENCE-MAP.md section 3.5(a) reported. This fixture fails
+ * loudly if that regresses.
+ */
+const FULL_RANGE_RAMP = frame(160, 100, (i) => { const v = i % 256; return [v, v, v]; });
 
 describe('luminanceStats — the numbers', () => {
     it('reads every pixel of a well-formed buffer', () => {
@@ -106,6 +116,19 @@ describe('luminanceStats — the numbers', () => {
         // marshals `[...data]`. If this function only accepted typed arrays the
         // smoke test would have had to reimplement it.
         expect(luminanceStats([...SOLID_GREY])).toEqual(luminanceStats(SOLID_GREY));
+    });
+
+    it('a full-range ramp hits exactly 32 buckets -- never 33', () => {
+        // The regression this fixture pins: floor(l / 8) over luminance
+        // 0..255 lands in 0..31 (32 distinct buckets), matching the doc
+        // comment on `LuminanceStats.buckets` and the `/32` suffix in
+        // `describeStats`. The prior `Math.round(l / 8)` produced a 33rd,
+        // impossible bucket (`round(255 / 8) === 32`) -- printing
+        // `buckets=33/32`, reported in `docs/CONFIDENCE-MAP.md` section 3.5(a).
+        const s = luminanceStats(FULL_RANGE_RAMP);
+        expect(s.buckets).toBe(32);
+        expect(s.buckets).not.toBe(33);
+        expect(describeStats(s)).toMatch(/buckets=32\/32/);
     });
 });
 

--- a/worker/scripts/mobile-keyboard.container.test.ts
+++ b/worker/scripts/mobile-keyboard.container.test.ts
@@ -173,6 +173,32 @@ import path from 'node:path';
  */
 const IMAGE = process.env.EZIL_VALIDATE_IMAGE ?? process.env.EZIL_NEKO_IMAGE ?? 'ezil-integrated:local';
 const CONTAINER = `ezil-kbd-test-${process.pid}`;
+
+/**
+ * SIGTERM/SIGINT SURVIVAL -- docs/CONFIDENCE-MAP.md section 2.10 / section 3.9,
+ * reproduced against `neko-browser-window.container.test.ts` (same shape:
+ * boot at module scope, cleanup only in `afterAll`). `afterAll` alone only
+ * fires on a normal bun-test exit; a cancellation (Ctrl-C, a CI job
+ * cancellation, a harness timeout that sends SIGTERM) skips straight past it
+ * and orphans a container built from a 4.57 GB image. So this container's
+ * name is registered in a module-level set that a process-level signal
+ * handler removes on the way out. `spawnSync`, not an async shape, because
+ * Node/Bun runs `exit` handlers SYNCHRONOUSLY -- an outstanding async
+ * `docker rm -f` would never be awaited and would not survive `exit` at all.
+ */
+const CONTAINERS_TO_CLEAN = new Set<string>();
+let cleanupOnExitInstalled = false;
+function installCleanupOnExit() {
+  if (cleanupOnExitInstalled) return;
+  cleanupOnExitInstalled = true;
+  const removeAll = () => {
+    for (const name of CONTAINERS_TO_CLEAN) sh('docker', ['rm', '-f', name], 60_000);
+  };
+  process.on('exit', removeAll);
+  process.on('SIGTERM', () => { removeAll(); process.exit(143); });
+  process.on('SIGINT', () => { removeAll(); process.exit(130); });
+}
+installCleanupOnExit();
 const PORT = 18291;
 const SIDECAR_PORT = 18292;
 const PAGE_PORT = 3112;   // served INSIDE the container
@@ -306,6 +332,7 @@ function boot(): void {
   ], 120_000);
   if (run.status !== 0) throw new Error(`docker run failed: ${(run.stderr || '').trim()}`);
   started = true;
+  CONTAINERS_TO_CLEAN.add(CONTAINER);
 
   const deadline = Date.now() + BOOT_TIMEOUT_MS;
   while (Date.now() < deadline) {

--- a/worker/src/browser-sidecar.container.test.ts
+++ b/worker/src/browser-sidecar.container.test.ts
@@ -37,6 +37,32 @@ import { createHash } from 'node:crypto';
 /** Same default and override as `neko-browser-window.container.test.ts`. */
 const IMAGE = process.env.EZIL_VALIDATE_IMAGE ?? 'ezil-integrated:local';
 const CONTAINER = `ezil-s1-sidecar-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+
+/**
+ * SIGTERM/SIGINT SURVIVAL -- docs/CONFIDENCE-MAP.md section 2.10 / section 3.9,
+ * reproduced against `neko-browser-window.container.test.ts` (this suite's
+ * sibling, same shape). `afterAll` alone only fires on a normal bun-test
+ * exit; a cancellation (Ctrl-C, a CI job cancellation, a harness timeout that
+ * sends SIGTERM) skips straight past it and orphans a container built from a
+ * 4.57 GB image. So this container's name is registered in a module-level
+ * set that a process-level signal handler removes on the way out.
+ * `spawnSync`, not an async shape, because Node/Bun runs `exit` handlers
+ * SYNCHRONOUSLY -- an outstanding async `docker rm -f` would never be
+ * awaited and would not survive `exit` at all.
+ */
+const CONTAINERS_TO_CLEAN = new Set<string>();
+let cleanupOnExitInstalled = false;
+function installCleanupOnExit () {
+    if (cleanupOnExitInstalled) return;
+    cleanupOnExitInstalled = true;
+    const removeAll = () => {
+        for (const name of CONTAINERS_TO_CLEAN) sh('docker', ['rm', '-f', name], 60_000);
+    };
+    process.on('exit', removeAll);
+    process.on('SIGTERM', () => { removeAll(); process.exit(143); });
+    process.on('SIGINT', () => { removeAll(); process.exit(130); });
+}
+installCleanupOnExit();
 const BOOT_TIMEOUT_MS = 180_000;
 
 /** Where the in-container fixture is served. Loopback only — `/navigate`
@@ -119,6 +145,7 @@ function boot (): void {
     ], 120_000);
     if (run.status !== 0) throw new Error(`docker run failed: ${(run.stderr || '').trim()}`);
     started = true;
+    CONTAINERS_TO_CLEAN.add(CONTAINER);
 
     const deadline = Date.now() + BOOT_TIMEOUT_MS;
     let ready = false;

--- a/worker/src/neko-browser-window.container.test.ts
+++ b/worker/src/neko-browser-window.container.test.ts
@@ -73,6 +73,32 @@ const IMAGE = process.env.EZIL_VALIDATE_IMAGE ?? 'ezil-integrated:local';
 const VALIDATOR = join(import.meta.dir, '..', 'scripts', 'validate-neko-browser-window.sh');
 const CONTAINER = `ezil-w9-validate-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
 
+/**
+ * SIGTERM/SIGINT SURVIVAL -- docs/CONFIDENCE-MAP.md section 2.10 / section 3.9.
+ * `afterAll` alone only fires on a normal bun-test exit; a cancellation
+ * (Ctrl-C, a CI job cancellation, a harness timeout that sends SIGTERM) skips
+ * straight past it and orphans a container built from a 4.57 GB image --
+ * measured: one held 456.2 MiB for eight minutes after its owning process was
+ * gone. So this container's name is registered in a module-level set that a
+ * process-level signal handler removes on the way out. `spawnSync`, not an
+ * async shape, because Node/Bun runs `exit` handlers SYNCHRONOUSLY -- an
+ * outstanding async `docker rm -f` would never be awaited and would not
+ * survive `exit` at all.
+ */
+const CONTAINERS_TO_CLEAN = new Set<string>();
+let cleanupOnExitInstalled = false;
+function installCleanupOnExit () {
+    if (cleanupOnExitInstalled) return;
+    cleanupOnExitInstalled = true;
+    const removeAll = () => {
+        for (const name of CONTAINERS_TO_CLEAN) sh('docker', ['rm', '-f', name], 60_000);
+    };
+    process.on('exit', removeAll);
+    process.on('SIGTERM', () => { removeAll(); process.exit(143); });
+    process.on('SIGINT', () => { removeAll(); process.exit(130); });
+}
+installCleanupOnExit();
+
 /** Boot budget. The pinned build reaches `phase=ready status=ok` in ~11s. */
 const BOOT_TIMEOUT_MS = 180_000;
 
@@ -130,6 +156,7 @@ function bootAndValidate (): Run {
         throw new Error(`docker run failed: ${(run.stderr || '').trim()}`);
     }
     started = true;
+    CONTAINERS_TO_CLEAN.add(CONTAINER);
 
     // Wait for start-neko.sh's own readiness line, not a fixed sleep.
     const deadline = Date.now() + BOOT_TIMEOUT_MS;


### PR DESCRIPTION
Row I0d of round INTAKE, from the interim verification's findings.

- The three worker container suites now register every container they create and remove them synchronously on `exit`, `SIGTERM` and `SIGINT` (kept: the existing `afterAll`). Proof on the suite the map reproduced: container up in 2 s, `kill -TERM` → bun exited 143, `docker ps -a` shows nothing left. Before this, a cancelled run orphaned a 456 MiB container for eight minutes.
- `local/src/pixels.ts`: `floor(l/8)` over 0…31 — exactly 32 buckets; the printed `buckets=N/32` is now arithmetically possible (mutant `Math.round` → Expected 32, Received 33). Smoke still passes on real frames: `stdDev 58.8, buckets 28/32`.
- Worker suite: 1075 pass / 1 known skip / 1 fail — the fail is the mobile-keyboard 48px-affordance test against this host's `ezil-integrated:local` (built from `wip/mobile-keyboard`, per M1); against a clean build it is 9/0 in this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)